### PR TITLE
Reduce event loop lag by signing aggregation selection proofs in batches

### DIFF
--- a/grafana/vero-detailed.json
+++ b/grafana/vero-detailed.json
@@ -3727,14 +3727,14 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "rate(event_loop_lag_seconds_sum{instance=\"$instance\"}[$__rate_interval])\n/\nrate(event_loop_lag_seconds_count[$__rate_interval])",
+              "expr": "histogram_quantile(0.99, event_loop_lag_seconds_bucket{instance=\"$instance\"})",
               "instant": false,
-              "legendFormat": "Event Loop Lag",
+              "legendFormat": "Event Loop Lag - 99% quantile",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Event Loop Lag",
+          "title": "Event Loop Lag - 99% quantile",
           "type": "timeseries"
         },
         {

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -168,6 +168,10 @@ async def run_services(cli_args: CLIArgs) -> None:
 
         while True:
             await asyncio.sleep(_interval)
-            EVENT_LOOP_LAG.observe(event_loop.time() - _start - _interval)
+
+            lag = event_loop.time() - _start - _interval
+            if lag > 0.5:
+                _logger.warning(f"Event loop lag high: {lag}")
+            EVENT_LOOP_LAG.observe(lag)
             EVENT_LOOP_TASKS.set(len(asyncio.all_tasks(event_loop)))
             _start = event_loop.time()


### PR DESCRIPTION
Running a high number of validators on Gnosis Chain revealed that the event loop lag regularly increased to very high values. This in turn caused blocks to be submitted late, especially during the first slot of an epoch.

This PR changes the way aggregation duty selection proofs are signed, signing them in batches instead of all at the same time. A warning-level log message is also added to indicate issues with a high event loop lag.

Before:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/c6d09b22-e72c-4dad-976f-a61b582151ba">

After:
<img width="739" alt="image" src="https://github.com/user-attachments/assets/5a633462-02f9-4984-9559-c13d11f951d6">

There's likely more room for improvement in terms of resource contention, but this fix does reduce the event loop lag to manageable levels even for a high number of validators.