### PR TITLE
Handle aggregates and contributions concurrently

### DIFF
--- a/src/providers/remote_signer.py
+++ b/src/providers/remote_signer.py
@@ -147,7 +147,9 @@ class RemoteSigner:
         message: SchemaRemoteSigner.SignableMessageT,
         identifier: str,
     ) -> tuple[SchemaRemoteSigner.SignableMessageT, str, str]:
-        """:param message: SignableMessage to sign
+        """
+
+        :param message: SignableMessage to sign
         :param identifier: BLS public key in hex format for which data to sign
         :
         """


### PR DESCRIPTION
Before this PR, this is how attestation aggregates were done:
(same applies to sync committee contributions)

1. Get aggregate attestations for all aggregator duties
2. Sign all the aggregate attestations
3. Publish all the aggregate attestations

-> If one of the aggregates took a bit longer to retrieve, the rest of them also waited for it, even though they could have already been signed and published.

With this PR, once any aggregate attestation is available, it is signed and published in a separate, independent task.