### PR TITLE
Remove Grandine-specific limitations

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,14 +4,14 @@ Vero regularly undergoes thorough testing against various CL and EL client combi
 
 It is currently compatible with all open-source Ethereum clients:
 
-|                | Compatible | Version  | Notes                                                                |
-|----------------|------------|----------|----------------------------------------------------------------------|
-| **Grandine**   | 🟡         | 0.4.0+   | Slashing SSE events not supported yet - slashing detection is slower |
-| **Lighthouse** | ✅          | v4.6.0+  |                                                                      |
-| **Lodestar**   | ✅          | v1.12.0+ |                                                                      |
-| **Nimbus**     | ✅          | v24.1.1+ |                                                                      |
-| **Prysm**      | ✅          | v4.2.0   |                                                                      |
-| **Teku**       | ✅          | 23.11.0+ |                                                                      |
+|                | Compatible | Version  | Notes |
+|----------------|------------|----------|---|
+| **Grandine**   | ✅          | 1.0.0+   |   |
+| **Lighthouse** | ✅          | v4.6.0+  |   |
+| **Lodestar**   | ✅          | v1.12.0+ |   |
+| **Nimbus**     | ✅          | v24.1.1+ |   |
+| **Prysm**      | ✅          | v4.2.0   |   |
+| **Teku**       | ✅          | 23.11.0+ |   |
 
 #### Legend
 ✅ Everything works perfectly.

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -416,26 +416,17 @@ class BeaconNode:
         if len(ids) == 0:
             return []
 
-        try:
-            resp_text = await self._make_request(
-                method="POST",
-                endpoint="/eth/v1/beacon/states/{state_id}/validators",
-                formatted_endpoint_string_params=dict(state_id=state_id),
-                data=self.json_encoder.encode(
-                    {
-                        "ids": ids,
-                        "statuses": [s.value for s in statuses],
-                    }
-                ),
-            )
-        except BeaconNodeUnsupportedEndpoint:
-            # Grandine doesn't support the POST endpoint yet
-            # -> fall back to GET endpoint
-            return await self._get_validators_fallback(
-                ids=ids,
-                statuses=statuses,
-                state_id=state_id,
-            )
+        resp_text = await self._make_request(
+            method="POST",
+            endpoint="/eth/v1/beacon/states/{state_id}/validators",
+            formatted_endpoint_string_params=dict(state_id=state_id),
+            data=self.json_encoder.encode(
+                {
+                    "ids": ids,
+                    "statuses": [s.value for s in statuses],
+                }
+            ),
+        )
 
         resp_decoded = msgspec.json.decode(
             resp_text, type=SchemaBeaconAPI.GetStateValidatorsResponse

--- a/src/services/event_consumer.py
+++ b/src/services/event_consumer.py
@@ -55,10 +55,6 @@ class EventConsumerService:
         primary_bn = self.multi_beacon_node.primary_beacon_node
 
         topics = ["head", "chain_reorg", "attester_slashing", "proposer_slashing"]
-        if "grandine" in beacon_node.node_version.lower():
-            # Grandine doesn't support the slashing SSE events
-            for t in ("attester_slashing", "proposer_slashing"):
-                topics.remove(t)
 
         try:
             async for event in beacon_node.subscribe_to_events(topics=topics):


### PR DESCRIPTION
This removes parts of the code that were necessary specifically for Grandine.

The next Grandine release will support SSE slashing events, as well as the POST `/eth/v1/beacon/states/{state_id}/validators` Beacon API endpoint.