### PR TITLE
Add `delete-old-package-versions` GitHub action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,3 +50,18 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.docker_metadata.outputs.tags }}
         labels: ${{ steps.docker_metadata.outputs.labels }}
+
+  delete-old-package-versions:
+    runs-on: ubuntu-latest
+
+    # Runs after the build-and-push job
+    needs: build-and-push
+
+    steps:
+    - name: Delete old untagged package versions
+      uses: actions/delete-package-versions@v5
+      with:
+        package-name: 'vero'
+        package-type: 'container'
+        min-versions-to-keep: 30
+        delete-only-untagged-versions: 'true'


### PR DESCRIPTION
There have been reports of this action not working correctly for multiarch images, corrupting/breaking repository images...

Not merging this PR (and therefore not cleaning up the old untagged versions) until that is resolved.