### PR TITLE
Remove `no-commit-to-branch` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: no-commit-to-branch
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
This hook causes the `pre-commit` GitHub action to fail on master -> remove it