### PR TITLE
Improve duty scheduling if preceding publish operation takes long

### DIFF
--- a/tests/services/test_attestation.py
+++ b/tests/services/test_attestation.py
@@ -99,8 +99,9 @@ async def test_aggregate_attestations(
 
     aggregates_produced_before = _VC_PUBLISHED_AGGREGATE_ATTESTATIONS._value.get()
     await attestation_service.aggregate_attestations(
+        slot=duty_slot,
         att_data=att_data,
-        slot_attester_duties=slot_attester_duties,
+        aggregator_duties={d for d in slot_attester_duties if d.is_aggregator},
     )
 
     assert any("Published aggregate and proofs" in m for m in caplog.messages)

--- a/tests/services/test_sync_committee.py
+++ b/tests/services/test_sync_committee.py
@@ -91,9 +91,9 @@ async def test_aggregate_sync_messages(
         _VC_PUBLISHED_SYNC_COMMITTEE_CONTRIBUTIONS._value.get()
     )
     await sync_committee_service.aggregate_sync_messages(
-        duties_with_proofs=duties_with_proofs,
         duty_slot=duty_slot,
         beacon_block_root="0x" + os.urandom(32).hex(),
+        duties_with_proofs=duties_with_proofs,
     )
 
     assert any(


### PR DESCRIPTION
If any of the beacon nodes Vero is connected to responds slowly when it publishes attestations (/sync messages), the subsequent scheduling of the aggregation (/sync contribution) duty may get delayed and even missed.

This PR moves the aggregation (/sync contribution) duty scheduling around so that it is no longer affected.