### PR TITLE
Improve logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ target-version = "py312"
 [tool.ruff.lint]
 # Enable all rules and explicitly disable some that we don't comply with (yet?)
 select = ["ALL"]
-ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM812", "ERA001", "E501", "FBT", "G004", "ISC001", "N805", "N812", "N818","TRY003"]
+ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM812", "ERA001", "E501", "FBT", "G004", "ISC001", "N805", "N812", "N818", "TRY003", "TRY400", "BLE001"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/mock_api/beacon_node.py" = ["C901"]

--- a/src/observability/_logging.py
+++ b/src/observability/_logging.py
@@ -17,7 +17,7 @@ def setup_logging(log_level: str) -> None:
     stream_handler.setFormatter(formatter)
     stream_handler.setLevel(log_level)
     root_logger.addHandler(stream_handler)
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(log_level)
     if log_level != logging.getLevelName(logging.DEBUG):
         # apscheduler is quite verbose with default INFO logging
         logging.getLogger("apscheduler").setLevel(logging.ERROR)

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -119,9 +119,10 @@ class BeaconNode:
             self.logger.info(
                 f"Initialized beacon node at {self.base_url}{f' [{function}]' if function else ''}",
             )
-        except Exception:
-            self.logger.exception(
-                f"Failed to initialize beacon node at {self.base_url}",
+        except Exception as e:
+            self.logger.error(
+                f"Failed to initialize beacon node at {self.base_url}: {e!r}",
+                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             # Retry initializing every 30 seconds
             next_run_time = datetime.datetime.now(tz=pytz.UTC) + datetime.timedelta(
@@ -214,7 +215,7 @@ class BeaconNode:
 
         try:
             version = json.loads(resp)["data"]["version"]
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             self.logger.warning(f"Failed to parse beacon node version: {e}")
             version = "unknown"
 
@@ -282,8 +283,11 @@ class BeaconNode:
                     )
                     if att_data.beacon_block_root.to_obj() == expected_head_block_root:
                         return att_data
-                except Exception:
-                    self.logger.exception("Failed to produce attestation data")
+                except Exception as e:
+                    self.logger.error(
+                        f"Failed to produce attestation data: {e!r}",
+                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
+                    )
 
                 # Rate-limiting - wait at least 50ms in between requests
                 elapsed_time = asyncio.get_event_loop().time() - _request_start_time
@@ -603,6 +607,11 @@ class BeaconNode:
                     consensus_block_value=response.consensus_block_value,
                 ),
             )
+            block_value = (
+                response.consensus_block_value + response.execution_payload_value
+            )
+            self.logger.info(f"{self.host} returned block with value {block_value}")
+
             return response
 
     async def publish_block_v2(
@@ -682,7 +691,9 @@ class BeaconNode:
             url=self.base_url.join(URL("/eth/v1/events")),
             params={"topics": ",".join(topics)},
             headers={"accept": "text/event-stream"},
-            timeout=ClientTimeout(total=None),  # Defaults to 5 minutes
+            timeout=ClientTimeout(
+                sock_connect=1, sock_read=None
+            ),  # Defaults to 5 minutes
         ) as resp:
             # Minimal SSE client implementation
             events_iter = aiter(resp.content)
@@ -703,9 +714,10 @@ class BeaconNode:
 
                 try:
                     event_name = decoded.split(":")[1].strip()
-                except Exception:
-                    self.logger.exception(
-                        f"Failed to parse event name from {decoded} -> ignoring event...",
+                except Exception as e:
+                    self.logger.error(
+                        f"Failed to parse event name from {decoded} ({e!r}) -> ignoring event...",
+                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     continue
                 event_data = []

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -273,7 +273,7 @@ class AttestationService(ValidatorDutyService):
                 ),
             )
 
-            self.logger.info(
+            self.logger.debug(
                 f"Publishing attestations for slot {slot}, count: {len(attestations_objects_to_publish)}",
             )
 
@@ -298,7 +298,7 @@ class AttestationService(ValidatorDutyService):
                     publish_span.set_status(Status(StatusCode.ERROR))
                     publish_span.record_exception(e)
                 else:
-                    self.logger.debug(
+                    self.logger.info(
                         f"Published attestations for slot {slot}, count: {len(attestations_objects_to_publish)}",
                     )
 
@@ -393,8 +393,8 @@ class AttestationService(ValidatorDutyService):
         committee_indices = {d.committee_index for d in aggregator_duties}
 
         aggregate_count = 0
-        self.logger.info(
-            f"Publishing aggregate and proofs for slot {att_data.slot}",
+        self.logger.debug(
+            f"Starting aggregate and proof sign-and-publish tasks for slot {att_data.slot}",
         )
 
         _fork_info = self.beacon_chain.get_fork_info(slot=slot)
@@ -431,7 +431,7 @@ class AttestationService(ValidatorDutyService):
             )
 
         await asyncio.gather(*_sign_and_publish_tasks)
-        self.logger.debug(
+        self.logger.info(
             f"Published aggregate and proofs for slot {att_data.slot}, count: {aggregate_count}",
         )
 

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -113,10 +113,13 @@ class AttestationService(ValidatorDutyService):
             if self.validator_status_tracker_service.slashing_detected:
                 raise RuntimeError("Slashing detected, not attesting")
 
-            if slot <= self._last_slot_duty_performed_for:
-                self.logger.warning(
-                    f"Not attesting to slot {slot} (already started attesting to slot {self._last_slot_duty_performed_for})",
-                )
+            if slot < self._last_slot_duty_performed_for:
+                return
+            if slot == self._last_slot_duty_performed_for:
+                if head_event:
+                    self.logger.warning(
+                        f"Ignoring head event, already started attesting to slot {self._last_slot_duty_performed_for}",
+                    )
                 return
             self._last_slot_duty_performed_for = slot
 

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -174,7 +174,7 @@ class SyncCommitteeService(ValidatorDutyService):
             ),
         )
 
-        self.logger.info(
+        self.logger.debug(
             f"Publishing sync committee messages for slot {duty_slot}, count: {len(sync_committee_members)}",
         )
 
@@ -194,7 +194,7 @@ class SyncCommitteeService(ValidatorDutyService):
                 exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
         else:
-            self.logger.debug(
+            self.logger.info(
                 f"Published sync committee messages for slot {duty_slot}, count: {len(sync_committee_members)}",
             )
             _VC_PUBLISHED_SYNC_COMMITTEE_MESSAGES.inc(
@@ -349,8 +349,8 @@ class SyncCommitteeService(ValidatorDutyService):
         }
 
         contribution_count = 0
-        self.logger.info(
-            f"Publishing sync committee contribution and proofs for slot {duty_slot}"
+        self.logger.debug(
+            f"Starting sync committee contribution and proof sign-and-publish tasks for slot {duty_slot}",
         )
 
         _fork_info = self.beacon_chain.get_fork_info(slot=duty_slot)
@@ -394,7 +394,7 @@ class SyncCommitteeService(ValidatorDutyService):
             )
 
         await asyncio.gather(*_sign_and_publish_tasks)
-        self.logger.debug(
+        self.logger.info(
             f"Published sync committee contribution and proofs for slot {duty_slot}, count: {contribution_count}"
         )
 

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -67,10 +67,13 @@ class SyncCommitteeService(ValidatorDutyService):
                 "Slashing detected, not producing sync committee message",
             )
 
-        if duty_slot <= self._last_slot_duty_performed_for:
-            self.logger.warning(
-                f"Not producing sync committee message during slot {duty_slot} (already started producing message during slot {self._last_slot_duty_performed_for})",
-            )
+        if duty_slot < self._last_slot_duty_performed_for:
+            return
+        if duty_slot == self._last_slot_duty_performed_for:
+            if head_event:
+                self.logger.warning(
+                    f"Ignoring head event, already started producing message during slot {self._last_slot_duty_performed_for}",
+                )
             return
         self._last_slot_duty_performed_for = duty_slot
 

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -107,9 +107,12 @@ class ValidatorDutyService:
         next_run_time = None
         try:
             await self._update_duties()
-        except Exception:
+        except Exception as e:
             _ERRORS_METRIC.labels(error_type=ErrorType.DUTIES_UPDATE.value).inc()
-            self.logger.exception("Failed to update duties")
+            self.logger.error(
+                f"Failed to update duties: {e!r}",
+                exc_info=self.logger.isEnabledFor(logging.DEBUG),
+            )
             next_run_time = datetime.datetime.now(tz=pytz.UTC) + datetime.timedelta(
                 seconds=1,
             )

--- a/src/services/validator_status_tracker.py
+++ b/src/services/validator_status_tracker.py
@@ -84,7 +84,7 @@ class ValidatorStatusTrackerService:
 
             if len(our_slashed_indices) > 0:
                 self.slashing_detected = True
-                self.logger.error(
+                self.logger.critical(
                     f"Slashing detected for validator indices {our_slashed_indices}",
                 )
             self.logger.info(
@@ -94,7 +94,7 @@ class ValidatorStatusTrackerService:
             slashed_validator_index = event.signed_header_1.message.proposer_index
             if slashed_validator_index in our_validator_indices:
                 self.slashing_detected = True
-                self.logger.error(
+                self.logger.critical(
                     f"Slashing detected for validator index {slashed_validator_index}",
                 )
             self.logger.info(
@@ -115,7 +115,7 @@ class ValidatorStatusTrackerService:
 
         if len(slashed_validators) > 0:
             self.slashing_detected = True
-            self.logger.error(
+            self.logger.critical(
                 f"Slashed validators detected while updating validator statuses. Slashed validators: {slashed_validators}",
             )
 
@@ -154,8 +154,11 @@ class ValidatorStatusTrackerService:
     async def update_validator_statuses(self) -> None:
         try:
             await self._update_validator_statuses()
-        except Exception:
-            self.logger.exception("Failed to update validator statuses")
+        except Exception as e:
+            self.logger.error(
+                f"Failed to update validator statuses: {e!r}",
+                exc_info=self.logger.isEnabledFor(logging.DEBUG),
+            )
 
         # Schedule the update of validator statuses
         # one slot before the next epoch starts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def _init_observability() -> None:
         metrics_address="localhost",
         metrics_port=8080,
         metrics_multiprocess_mode=False,
-        log_level="INFO",
+        log_level="DEBUG",
     )
 
 

--- a/tests/services/test_validator_status_tracker.py
+++ b/tests/services/test_validator_status_tracker.py
@@ -130,7 +130,7 @@ async def test_handle_slashing_event(
 
     if our_validator_affected:
         assert any("Slashing detected" in m for m in caplog.messages)
-        assert any(record.levelname == "ERROR" for record in caplog.records)
+        assert any(record.levelname == "CRITICAL" for record in caplog.records)
 
         # ValidatorStatusTracker property value should be set
         assert validator_status_tracker.slashing_detected is True


### PR DESCRIPTION
- Log the beacon node host along with the returned block's value.
- Do not log the full exception info unless debug logging is turned on.
- Refactor failed beacon node request logging
- Adjust message for late head events
- Set log level to critical for slashing events affecting managed validators