### PR TITLE
Adhere to Beacon API spec when subscribing to SSE stream

### DIFF
--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -724,7 +724,7 @@ class BeaconNode:
 
         async with self.client_session.get(
             url=self.base_url.join(URL("/eth/v1/events")),
-            params={"topics": ",".join(topics)},
+            params={"topics": topics},
             headers={"accept": "text/event-stream"},
             timeout=ClientTimeout(
                 sock_connect=1, sock_read=None


### PR DESCRIPTION
Most CLs support making a request in this format too: `/eth/v1/events?topics=head,block` but the spec says it should be `/eth/v1/events?topics=head&topics=block` .

Now it looks like the new Caplin CL doesn't support the `head,block` way so this seems like a good time to adhere to the spec.

I believe I "overrode" it this way because some CL didn't support the spec way of doing this, but when I tested it just now with the spec-adherent request format, they all work just fine.