### PR TITLE
Add `--network` CLI parameter

### DIFF
--- a/compose-example.yaml
+++ b/compose-example.yaml
@@ -1,8 +1,9 @@
 services:
   validator-client:
     container_name: validator-client
-    image: ghcr.io/serenita-org/vero:v0.8.2
+    image: ghcr.io/serenita-org/vero:v0.9.0
     command:
+      - "--network=holesky"
       - "--remote-signer-url=http://remote-signer:9000"
       - "--beacon-node-urls=http://beacon-node-1:1234,http://beacon-node-2:1234,http://beacon-node-3:1234"
       - "--fee-recipient=0x0000000000000000000000000000000000000000"

--- a/docs/running_vero.md
+++ b/docs/running_vero.md
@@ -37,6 +37,13 @@ Check out the [example docker compose file](../compose-example.yaml).
 
 # CLI Reference
 
+#### `--network`
+
+**[required]** The network to use, one of `mainnet,gnosis,holesky,fetch`.
+
+`fetch` is a special case where Vero uses the network specs as returned by the beacon nodes.
+___
+
 #### `--remote-signer-url`
 
 **[required]** URL of the remote signer, e.g. `http://remote-signer:9000`

--- a/src/args.py
+++ b/src/args.py
@@ -5,8 +5,11 @@ from urllib.parse import urlparse
 
 import msgspec
 
+from spec.configs import Network
+
 
 class CLIArgs(msgspec.Struct, kw_only=True):
+    network: Network
     remote_signer_url: str
     beacon_node_urls: list[str]
     beacon_node_urls_proposal: list[str]
@@ -91,6 +94,14 @@ def _process_graffiti(graffiti: str) -> bytes:
 def parse_cli_args(args: Sequence[str]) -> CLIArgs:
     parser = argparse.ArgumentParser(description="Vero validator client.")
 
+    _network_choices = [e.value for e in list(Network)]
+    parser.add_argument(
+        "--network",
+        type=str,
+        required=True,
+        choices=_network_choices,
+        help="The network to use. 'fetch' is a special case where Vero uses the network specs returned by the beacon node(s).",
+    )
     parser.add_argument(
         "--remote-signer-url", type=str, required=True, help="URL of the remote signer."
     )
@@ -193,6 +204,7 @@ def parse_cli_args(args: Sequence[str]) -> CLIArgs:
             )
         ]
         return CLIArgs(
+            network=Network(parsed_args.network),
             remote_signer_url=_validate_url(parsed_args.remote_signer_url),
             beacon_node_urls=beacon_node_urls,
             beacon_node_urls_proposal=[

--- a/src/spec/configs/__init__.py
+++ b/src/spec/configs/__init__.py
@@ -1,0 +1,47 @@
+import os
+from enum import Enum
+from pathlib import Path
+
+from spec.base import Spec, parse_spec
+
+
+class Network(Enum):
+    MAINNET = "mainnet"
+    GNOSIS = "gnosis"
+    HOLESKY = "holesky"
+
+    # Special case where Vero uses the network specs returned by the beacon node(s)
+    FETCH = "fetch"
+
+
+def parse_yaml_file(fp: Path) -> dict[str, str]:
+    return_dict: dict[str, str] = {}
+    with Path.open(fp) as f:
+        for line in f:
+            line = line.strip().split("#", maxsplit=1)[0]
+            if line == "":
+                continue
+
+            name, value = line.split(": ", maxsplit=1)
+            if name in return_dict:
+                raise ValueError(f"{name} already defined as {return_dict[name]}")
+            return_dict[name] = value.strip()
+    return return_dict
+
+
+def get_network_spec(network: Network) -> Spec:
+    spec_dict = {}
+
+    spec_dict.update(parse_yaml_file(Path(__file__).parent / f"{network.value}.yaml"))
+
+    preset_files_dir = (
+        Path(__file__).parent / "presets" / f"{spec_dict['PRESET_BASE'].strip("'")}"
+    )
+    for fname in os.listdir(preset_files_dir):
+        spec_dict.update(
+            parse_yaml_file(
+                Path(preset_files_dir) / fname,
+            )
+        )
+
+    return parse_spec(data=spec_dict)

--- a/src/spec/configs/gnosis.yaml
+++ b/src/spec/configs/gnosis.yaml
@@ -1,0 +1,46 @@
+PRESET_BASE: 'gnosis'
+
+# Free-form short name of the network that this configuration applies to - known
+# canonical network names include:
+# * 'mainnet' - there can be only one
+# * 'prater' - testnet
+# Must match the regex: [a-z0-9\-]
+CONFIG_NAME: 'gnosis'
+
+# Genesis
+# ---------------------------------------------------------------
+# Dec 08, 2021, 13:00 UTC
+MIN_GENESIS_TIME: 1638968400
+GENESIS_FORK_VERSION: 0x00000064
+
+
+# Forking
+# ---------------------------------------------------------------
+# Some forks are disabled for now:
+#  - These may be re-assigned to another fork-version later
+#  - Temporarily set to max uint64 value: 2**64 - 1
+
+# Altair
+ALTAIR_FORK_VERSION: 0x01000064
+ALTAIR_FORK_EPOCH: 512
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000064
+BELLATRIX_FORK_EPOCH: 385536  # 2022-11-30T19:23:40.000Z
+# Capella
+CAPELLA_FORK_VERSION: 0x03000064
+CAPELLA_FORK_EPOCH: 648704  # 2023-08-01T11:34:20.000Z
+# Deneb
+DENEB_FORK_VERSION: 0x04000064
+DENEB_FORK_EPOCH: 889856  # 2024-03-11T18:30:20.000Z
+
+# Time parameters
+# ---------------------------------------------------------------
+# 5 seconds
+SECONDS_PER_SLOT: 5
+
+# phase0
+INTERVALS_PER_SLOT: 3
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# altair
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 16
+SYNC_COMMITTEE_SUBNET_COUNT: 4

--- a/src/spec/configs/holesky.yaml
+++ b/src/spec/configs/holesky.yaml
@@ -1,0 +1,41 @@
+# Extends the mainnet preset
+PRESET_BASE: 'mainnet'
+CONFIG_NAME: holesky
+
+# Genesis
+# ---------------------------------------------------------------
+# Sep-28-2023 11:55:00 +UTC
+MIN_GENESIS_TIME: 1695902100
+GENESIS_FORK_VERSION: 0x01017000
+
+
+# Forking
+# ---------------------------------------------------------------
+# Some forks are disabled for now:
+#  - These may be re-assigned to another fork-version later
+#  - Temporarily set to max uint64 value: 2**64 - 1
+
+# Altair
+ALTAIR_FORK_VERSION: 0x02017000
+ALTAIR_FORK_EPOCH: 0
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x03017000
+BELLATRIX_FORK_EPOCH: 0
+# Capella
+CAPELLA_FORK_VERSION: 0x04017000
+CAPELLA_FORK_EPOCH: 256
+# Deneb
+DENEB_FORK_VERSION: 0x05017000
+DENEB_FORK_EPOCH: 29696
+
+# Time parameters
+# ---------------------------------------------------------------
+# 12 seconds
+SECONDS_PER_SLOT: 12
+
+# phase0
+INTERVALS_PER_SLOT: 3
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# altair
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 16
+SYNC_COMMITTEE_SUBNET_COUNT: 4

--- a/src/spec/configs/mainnet.yaml
+++ b/src/spec/configs/mainnet.yaml
@@ -1,0 +1,48 @@
+# Mainnet config
+
+# Extends the mainnet preset
+PRESET_BASE: 'mainnet'
+
+# Free-form short name of the network that this configuration applies to - known
+# canonical network names include:
+# * 'mainnet' - there can be only one
+# * 'prater' - testnet
+# Must match the regex: [a-z0-9\-]
+CONFIG_NAME: 'mainnet'
+
+# Genesis
+# ---------------------------------------------------------------
+# Dec 1, 2020, 12pm UTC
+MIN_GENESIS_TIME: 1606824000
+GENESIS_FORK_VERSION: 0x00000000
+
+# Forking
+# ---------------------------------------------------------------
+# Some forks are disabled for now:
+#  - These may be re-assigned to another fork-version later
+#  - Temporarily set to max uint64 value: 2**64 - 1
+
+# Altair
+ALTAIR_FORK_VERSION: 0x01000000
+ALTAIR_FORK_EPOCH: 74240  # Oct 27, 2021, 10:56:23am UTC
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x02000000
+BELLATRIX_FORK_EPOCH: 144896  # Sept 6, 2022, 11:34:47am UTC
+# Capella
+CAPELLA_FORK_VERSION: 0x03000000
+CAPELLA_FORK_EPOCH: 194048  # April 12, 2023, 10:27:35pm UTC
+# Deneb
+DENEB_FORK_VERSION: 0x04000000
+DENEB_FORK_EPOCH: 269568  # March 13, 2024, 01:55:35pm UTC
+
+# Time parameters
+# ---------------------------------------------------------------
+# 12 seconds
+SECONDS_PER_SLOT: 12
+
+# phase0
+INTERVALS_PER_SLOT: 3
+TARGET_AGGREGATORS_PER_COMMITTEE: 16
+# altair
+TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 16
+SYNC_COMMITTEE_SUBNET_COUNT: 4

--- a/src/spec/configs/presets/gnosis/altair.yaml
+++ b/src/spec/configs/presets/gnosis/altair.yaml
@@ -1,0 +1,26 @@
+# Mainnet preset - Altair
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 3 * 2**24 (= 50,331,648)
+INACTIVITY_PENALTY_QUOTIENT_ALTAIR: 50331648
+# 2**6 (= 64)
+MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: 64
+# 2
+PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
+
+
+# Sync committee
+# ---------------------------------------------------------------
+# 2**9 (= 512)
+SYNC_COMMITTEE_SIZE: 512
+# 2**9 (= 512)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 512
+
+
+# Sync protocol
+# ---------------------------------------------------------------
+# 1
+MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
+# SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD (= 32 * 256)
+UPDATE_TIMEOUT: 8192

--- a/src/spec/configs/presets/gnosis/bellatrix.yaml
+++ b/src/spec/configs/presets/gnosis/bellatrix.yaml
@@ -1,0 +1,21 @@
+# Mainnet preset - Bellatrix
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 2**24 (= 16,777,216)
+INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: 16777216
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: 32
+# 3
+PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: 3
+
+# Execution
+# ---------------------------------------------------------------
+# 2**30 (= 1,073,741,824)
+MAX_BYTES_PER_TRANSACTION: 1073741824
+# 2**20 (= 1,048,576)
+MAX_TRANSACTIONS_PER_PAYLOAD: 1048576
+# 2**8 (= 256)
+BYTES_PER_LOGS_BLOOM: 256
+# 2**5 (= 32)
+MAX_EXTRA_DATA_BYTES: 32

--- a/src/spec/configs/presets/gnosis/capella.yaml
+++ b/src/spec/configs/presets/gnosis/capella.yaml
@@ -1,0 +1,17 @@
+# Mainnet preset - Capella
+
+# Misc
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_BLS_TO_EXECUTION_CHANGES: 16
+
+# Execution
+# ---------------------------------------------------------------
+# 2**3 (= 8) withdrawals
+MAX_WITHDRAWALS_PER_PAYLOAD: 8
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**13 (= 8192) validators
+MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: 8192

--- a/src/spec/configs/presets/gnosis/deneb.yaml
+++ b/src/spec/configs/presets/gnosis/deneb.yaml
@@ -1,0 +1,10 @@
+# Mainnet preset - Deneb
+
+# Misc
+# ---------------------------------------------------------------
+# `uint64(4096)`
+FIELD_ELEMENTS_PER_BLOB: 4096
+# `uint64(2**12)` (= 4096)
+MAX_BLOB_COMMITMENTS_PER_BLOCK: 4096
+# `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 12 = 17
+KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: 17

--- a/src/spec/configs/presets/gnosis/phase0.yaml
+++ b/src/spec/configs/presets/gnosis/phase0.yaml
@@ -1,0 +1,77 @@
+# Mainnet preset - Phase0
+
+# Misc
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+MAX_COMMITTEES_PER_SLOT: 64
+# 2**7 (= 128)
+TARGET_COMMITTEE_SIZE: 128
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# See issue 563
+SHUFFLE_ROUND_COUNT: 90
+# 4
+HYSTERESIS_QUOTIENT: 4
+# 1 (minus 0.25)
+HYSTERESIS_DOWNWARD_MULTIPLIER: 1
+# 5 (plus 1.25)
+HYSTERESIS_UPWARD_MULTIPLIER: 5
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Time parameters
+# ---------------------------------------------------------------
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+SLOTS_PER_EPOCH: 16
+MIN_SEED_LOOKAHEAD: 1
+MAX_SEED_LOOKAHEAD: 4
+EPOCHS_PER_ETH1_VOTING_PERIOD: 64
+SLOTS_PER_HISTORICAL_ROOT: 8192
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+
+
+# State list lengths
+# ---------------------------------------------------------------
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+EPOCHS_PER_SLASHINGS_VECTOR: 8192
+HISTORICAL_ROOTS_LIMIT: 16777216
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 25
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**26 (= 67,108,864)
+INACTIVITY_PENALTY_QUOTIENT: 67108864
+# 2**7 (= 128) (lower safety margin at Phase 0 genesis)
+MIN_SLASHING_PENALTY_QUOTIENT: 128
+# 1 (lower safety margin at Phase 0 genesis)
+PROPORTIONAL_SLASHING_MULTIPLIER: 1
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16

--- a/src/spec/configs/presets/mainnet/altair.yaml
+++ b/src/spec/configs/presets/mainnet/altair.yaml
@@ -1,0 +1,26 @@
+# Mainnet preset - Altair
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 3 * 2**24 (= 50,331,648)
+INACTIVITY_PENALTY_QUOTIENT_ALTAIR: 50331648
+# 2**6 (= 64)
+MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: 64
+# 2
+PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
+
+
+# Sync committee
+# ---------------------------------------------------------------
+# 2**9 (= 512)
+SYNC_COMMITTEE_SIZE: 512
+# 2**8 (= 256)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
+
+
+# Sync protocol
+# ---------------------------------------------------------------
+# 1
+MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
+# SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD (= 32 * 256)
+UPDATE_TIMEOUT: 8192

--- a/src/spec/configs/presets/mainnet/bellatrix.yaml
+++ b/src/spec/configs/presets/mainnet/bellatrix.yaml
@@ -1,0 +1,21 @@
+# Mainnet preset - Bellatrix
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 2**24 (= 16,777,216)
+INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: 16777216
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: 32
+# 3
+PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: 3
+
+# Execution
+# ---------------------------------------------------------------
+# 2**30 (= 1,073,741,824)
+MAX_BYTES_PER_TRANSACTION: 1073741824
+# 2**20 (= 1,048,576)
+MAX_TRANSACTIONS_PER_PAYLOAD: 1048576
+# 2**8 (= 256)
+BYTES_PER_LOGS_BLOOM: 256
+# 2**5 (= 32)
+MAX_EXTRA_DATA_BYTES: 32

--- a/src/spec/configs/presets/mainnet/capella.yaml
+++ b/src/spec/configs/presets/mainnet/capella.yaml
@@ -1,0 +1,17 @@
+# Mainnet preset - Capella
+
+# Misc
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_BLS_TO_EXECUTION_CHANGES: 16
+
+# Execution
+# ---------------------------------------------------------------
+# 2**4 (= 16) withdrawals
+MAX_WITHDRAWALS_PER_PAYLOAD: 16
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**14 (= 16384) validators
+MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: 16384

--- a/src/spec/configs/presets/mainnet/deneb.yaml
+++ b/src/spec/configs/presets/mainnet/deneb.yaml
@@ -1,0 +1,10 @@
+# Mainnet preset - Deneb
+
+# Misc
+# ---------------------------------------------------------------
+# `uint64(4096)`
+FIELD_ELEMENTS_PER_BLOB: 4096
+# `uint64(2**12)` (= 4096)
+MAX_BLOB_COMMITMENTS_PER_BLOCK: 4096
+# `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 12 = 17
+KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: 17

--- a/src/spec/configs/presets/mainnet/phase0.yaml
+++ b/src/spec/configs/presets/mainnet/phase0.yaml
@@ -1,0 +1,88 @@
+# Mainnet preset - Phase0
+
+# Misc
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+MAX_COMMITTEES_PER_SLOT: 64
+# 2**7 (= 128)
+TARGET_COMMITTEE_SIZE: 128
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# See issue 563
+SHUFFLE_ROUND_COUNT: 90
+# 4
+HYSTERESIS_QUOTIENT: 4
+# 1 (minus 0.25)
+HYSTERESIS_DOWNWARD_MULTIPLIER: 1
+# 5 (plus 1.25)
+HYSTERESIS_UPWARD_MULTIPLIER: 5
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 2**0 (= 1) slots 12 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# 2**5 (= 32) slots 6.4 minutes
+SLOTS_PER_EPOCH: 32
+# 2**0 (= 1) epochs 6.4 minutes
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs 25.6 minutes
+MAX_SEED_LOOKAHEAD: 4
+# 2**6 (= 64) epochs ~6.8 hours
+EPOCHS_PER_ETH1_VOTING_PERIOD: 64
+# 2**13 (= 8,192) slots ~27 hours
+SLOTS_PER_HISTORICAL_ROOT: 8192
+# 2**2 (= 4) epochs 25.6 minutes
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+
+
+# State list lengths
+# ---------------------------------------------------------------
+# 2**16 (= 65,536) epochs ~0.8 years
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+# 2**13 (= 8,192) epochs ~36 days
+EPOCHS_PER_SLASHINGS_VECTOR: 8192
+# 2**24 (= 16,777,216) historical roots, ~26,131 years
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**26 (= 67,108,864)
+INACTIVITY_PENALTY_QUOTIENT: 67108864
+# 2**7 (= 128) (lower safety margin at Phase 0 genesis)
+MIN_SLASHING_PENALTY_QUOTIENT: 128
+# 1 (lower safety margin at Phase 0 genesis)
+PROPORTIONAL_SLASHING_MULTIPLIER: 1
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16

--- a/src/spec/configs/presets/minimal/altair.yaml
+++ b/src/spec/configs/presets/minimal/altair.yaml
@@ -1,0 +1,26 @@
+# Minimal preset - Altair
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 3 * 2**24 (= 50,331,648)
+INACTIVITY_PENALTY_QUOTIENT_ALTAIR: 50331648
+# 2**6 (= 64)
+MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: 64
+# 2
+PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
+
+
+# Sync committee
+# ---------------------------------------------------------------
+# [customized]
+SYNC_COMMITTEE_SIZE: 32
+# [customized]
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 8
+
+
+# Sync protocol
+# ---------------------------------------------------------------
+# 1
+MIN_SYNC_COMMITTEE_PARTICIPANTS: 1
+# SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD (= 8 * 8)
+UPDATE_TIMEOUT: 64

--- a/src/spec/configs/presets/minimal/bellatrix.yaml
+++ b/src/spec/configs/presets/minimal/bellatrix.yaml
@@ -1,0 +1,21 @@
+# Minimal preset - Bellatrix
+
+# Updated penalty values
+# ---------------------------------------------------------------
+# 2**24 (= 16,777,216)
+INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: 16777216
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: 32
+# 3
+PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: 3
+
+# Execution
+# ---------------------------------------------------------------
+# 2**30 (= 1,073,741,824)
+MAX_BYTES_PER_TRANSACTION: 1073741824
+# 2**20 (= 1,048,576)
+MAX_TRANSACTIONS_PER_PAYLOAD: 1048576
+# 2**8 (= 256)
+BYTES_PER_LOGS_BLOOM: 256
+# 2**5 (= 32)
+MAX_EXTRA_DATA_BYTES: 32

--- a/src/spec/configs/presets/minimal/capella.yaml
+++ b/src/spec/configs/presets/minimal/capella.yaml
@@ -1,0 +1,17 @@
+# Minimal preset - Capella
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_BLS_TO_EXECUTION_CHANGES: 16
+
+
+# Execution
+# ---------------------------------------------------------------
+# [customized] 2**2 (= 4)
+MAX_WITHDRAWALS_PER_PAYLOAD: 4
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# [customized] 2**4 (= 16) validators
+MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: 16

--- a/src/spec/configs/presets/minimal/deneb.yaml
+++ b/src/spec/configs/presets/minimal/deneb.yaml
@@ -1,0 +1,10 @@
+# Minimal preset - Deneb
+
+# Misc
+# ---------------------------------------------------------------
+# `uint64(4096)`
+FIELD_ELEMENTS_PER_BLOB: 4096
+# [customized]
+MAX_BLOB_COMMITMENTS_PER_BLOCK: 32
+# [customized] `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 5 = 10
+KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: 10

--- a/src/spec/configs/presets/minimal/phase0.yaml
+++ b/src/spec/configs/presets/minimal/phase0.yaml
@@ -1,0 +1,88 @@
+# Minimal preset - Phase0
+
+# Misc
+# ---------------------------------------------------------------
+# [customized] Just 4 committees for slot for testing purposes
+MAX_COMMITTEES_PER_SLOT: 4
+# [customized] insecure, but fast
+TARGET_COMMITTEE_SIZE: 4
+# 2**11 (= 2,048)
+MAX_VALIDATORS_PER_COMMITTEE: 2048
+# [customized] Faster, but insecure.
+SHUFFLE_ROUND_COUNT: 10
+# 4
+HYSTERESIS_QUOTIENT: 4
+# 1 (minus 0.25)
+HYSTERESIS_DOWNWARD_MULTIPLIER: 1
+# 5 (plus 1.25)
+HYSTERESIS_UPWARD_MULTIPLIER: 5
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 2**0 (= 1) slots 6 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# [customized] fast epochs
+SLOTS_PER_EPOCH: 8
+# 2**0 (= 1) epochs
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs
+MAX_SEED_LOOKAHEAD: 4
+# [customized] higher frequency new deposits from eth1 for testing
+EPOCHS_PER_ETH1_VOTING_PERIOD: 4
+# [customized] smaller state
+SLOTS_PER_HISTORICAL_ROOT: 64
+# 2**2 (= 4) epochs
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+
+
+# State list lengths
+# ---------------------------------------------------------------
+# [customized] smaller state
+EPOCHS_PER_HISTORICAL_VECTOR: 64
+# [customized] smaller state
+EPOCHS_PER_SLASHINGS_VECTOR: 64
+# 2**24 (= 16,777,216) historical roots
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# [customized] 2**25 (= 33,554,432)
+INACTIVITY_PENALTY_QUOTIENT: 33554432
+# [customized] 2**6 (= 64)
+MIN_SLASHING_PENALTY_QUOTIENT: 64
+# [customized] 2 (lower safety margin than Phase 0 genesis but different than mainnet config for testing)
+PROPORTIONAL_SLASHING_MULTIPLIER: 2
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from providers import BeaconChain, MultiBeaconNode, RemoteSigner
 from schemas import SchemaBeaconAPI
 from schemas.validator import ACTIVE_STATUSES, ValidatorIndexPubkey
 from services import ValidatorStatusTrackerService
+from spec.configs import Network
 
 # A few more global fixtures defined separately
 from tests.mock_api.base import *
@@ -36,6 +37,7 @@ def cli_args(
     beacon_node_urls_proposal: list[str],
 ) -> CLIArgs:
     return CLIArgs(
+        network=Network.FETCH,
         remote_signer_url=remote_signer_url,
         beacon_node_urls=[beacon_node_url],
         beacon_node_urls_proposal=beacon_node_urls_proposal,

--- a/tests/spec/configs/test_spec_configs.py
+++ b/tests/spec/configs/test_spec_configs.py
@@ -1,0 +1,11 @@
+import pytest
+
+from spec.configs import Network, get_network_spec
+
+
+@pytest.mark.parametrize(
+    argnames="network",
+    argvalues=[network for network in Network if network != Network.FETCH],
+)
+def test_get_network_spec(network: Network) -> None:
+    _ = get_network_spec(network=network)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 from args import parse_cli_args
+from spec.configs import Network
 
 
 @pytest.mark.parametrize(
@@ -14,18 +15,20 @@ from args import parse_cli_args
     argvalues=[
         pytest.param(
             [],
-            "the following arguments are required: --remote-signer-url, --beacon-node-urls, --fee-recipient",
+            "the following arguments are required: --network, --remote-signer-url, --beacon-node-urls, --fee-recipient\n",
             {},
             id="No arguments provided",
         ),
         pytest.param(
             [
+                "--network=mainnet",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
             ],
             None,
             {
+                "network": Network.MAINNET,
                 "remote_signer_url": "http://signer:9000",
                 "beacon_node_urls": ["http://beacon-node:5052"],
                 "beacon_node_urls_proposal": [],
@@ -36,6 +39,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--beacon-node-urls-proposal=http://beacon-node-prop:5052",
@@ -53,6 +57,7 @@ from args import parse_cli_args
             ],
             None,
             {
+                "network": Network.FETCH,
                 "remote_signer_url": "http://signer:9000",
                 "beacon_node_urls": ["http://beacon-node:5052"],
                 "beacon_node_urls_proposal": ["http://beacon-node-prop:5052"],
@@ -72,23 +77,23 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node-1:5052,http://beacon-node-2:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
             ],
             None,
             {
-                "remote_signer_url": "http://signer:9000",
                 "beacon_node_urls": [
                     "http://beacon-node-1:5052",
                     "http://beacon-node-2:5052",
                 ],
-                "fee_recipient": "0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
             },
             id="--beacon-node-urls valid input - multiple values",
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=   ",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -99,6 +104,18 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=sepolia",
+                "--remote-signer-url=http://signer:9000",
+                "--beacon-node-urls=   ",
+                "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
+            ],
+            "argument --network: invalid choice: 'sepolia'",
+            {},
+            id="--network invalid input - unsupported network",
+        ),
+        pytest.param(
+            [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node-1:5052,http://beacon-node-2:5052,http://beacon-node-1:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -109,6 +126,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--beacon-node-urls-proposal=http://beacon-node-prop:5052",
@@ -123,6 +141,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--attestation-consensus-threshold=asd",
@@ -134,6 +153,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--attestation-consensus-threshold=2",
@@ -145,6 +165,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--attestation-consensus-threshold=0",
@@ -156,6 +177,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c",
@@ -166,6 +188,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -176,6 +199,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0xGGGG96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -186,6 +210,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -197,6 +222,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -208,6 +234,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -219,6 +246,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -230,6 +258,7 @@ from args import parse_cli_args
         ),
         pytest.param(
             [
+                "--network=fetch",
                 "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",


### PR DESCRIPTION
I initially thought explicitly specifying the network wouldn't be that useful for validator clients since they can just retrieve the network specs from the connected beacon node.

However, there are a few things that are network-specific and will be easier to handle if Vero is explicitly aware of the network being used:
- gas limit (we may want to use different defaults for different networks)
- block value comparison - Gnosis Chain EL rewards are in xDAI and cannot be easily/directly compared to CL rewards

It is still possible to use the old behavior (not using the hardcoded specs) using the `fetch` value for the `network` parameter. This is mostly intended to be used for local devnets. All public networks supported by Vero should be added as parameter options. Right now that means `mainnet`, `gnosis` and `holesky`.