### PR TITLE
Change scheduler log level to warning

### DIFF
--- a/src/observability/_logging.py
+++ b/src/observability/_logging.py
@@ -20,4 +20,4 @@ def setup_logging(log_level: str) -> None:
     root_logger.setLevel(log_level)
     if log_level != logging.getLevelName(logging.DEBUG):
         # apscheduler is quite verbose with default INFO logging
-        logging.getLogger("apscheduler").setLevel(logging.ERROR)
+        logging.getLogger("apscheduler").setLevel(logging.WARNING)


### PR DESCRIPTION
The `apscheduler` module was overridden to `ERROR` since at `INFO` it was too verbose.

This PR changes the log level to `WARNING` since at that log level the output is still not too verbose and it may help while debugging missed job executions.