### PR TITLE
Track all validator statuses

### DIFF
--- a/grafana/vero-detailed.json
+++ b/grafana/vero-detailed.json
@@ -433,6 +433,7 @@
         "y": 5
       },
       "id": 34,
+      "interval": "1m",
       "maxDataPoints": 50,
       "options": {
         "legend": {
@@ -504,6 +505,51 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "exited"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "withdrawal"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -540,28 +586,39 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "validator_status{instance=\"$instance\", status!=\"other\"}",
+          "expr": "validator_status{instance=\"$instance\"}",
           "instant": false,
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "validator_status{instance=\"$instance\", status=\"other\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{status}}",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "Validators",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "active": 3,
+              "exited": 4,
+              "pending": 2,
+              "unknown": 1,
+              "withdrawal": 5
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "stat"
     },
     {
@@ -5732,6 +5789,6 @@
   "timezone": "",
   "title": "Vero - Detailed",
   "uid": "f3868b92-83fd-43a3-8d18-a74f35369590",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }

--- a/grafana/vero-simple.json
+++ b/grafana/vero-simple.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 2,
+  "id": 38,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -433,6 +433,7 @@
         "y": 5
       },
       "id": 34,
+      "interval": "1m",
       "maxDataPoints": 50,
       "options": {
         "legend": {
@@ -504,6 +505,51 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "exited"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "withdrawal"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -540,28 +586,39 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "validator_status{instance=\"$instance\", status!=\"other\"}",
+          "expr": "validator_status{instance=\"$instance\"}",
           "instant": false,
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "validator_status{instance=\"$instance\", status=\"other\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{status}}",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "Validators",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "Time",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "active": 3,
+              "exited": 4,
+              "pending": 2,
+              "unknown": 1,
+              "withdrawal": 5
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "stat"
     },
     {
@@ -1039,6 +1096,6 @@
   "timezone": "",
   "title": "Vero - Simple",
   "uid": "f3868b92-83fd-43a3-8e18-a74f35169590",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/schemas/beacon_api.py
+++ b/src/schemas/beacon_api.py
@@ -18,11 +18,15 @@ class ExecutionOptimisticResponse(msgspec.Struct):
 
 
 class ValidatorStatus(Enum):
+    PENDING_INITIALIZED = "pending_initialized"
+    PENDING_QUEUED = "pending_queued"
     ACTIVE_ONGOING = "active_ongoing"
     ACTIVE_EXITING = "active_exiting"
     ACTIVE_SLASHED = "active_slashed"
-    PENDING_INITIALIZED = "pending_initialized"
-    PENDING_QUEUED = "pending_queued"
+    EXITED_UNSLASHED = "exited_unslashed"
+    EXITED_SLASHED = "exited_slashed"
+    WITHDRAWAL_POSSIBLE = "withdrawal_possible"
+    WITHDRAWAL_DONE = "withdrawal_done"
 
 
 class Validator(msgspec.Struct):

--- a/src/schemas/validator.py
+++ b/src/schemas/validator.py
@@ -2,18 +2,30 @@ import msgspec
 
 from schemas import SchemaBeaconAPI
 
-ACTIVE_STATUSES = [
-    SchemaBeaconAPI.ValidatorStatus.ACTIVE_ONGOING,
-    SchemaBeaconAPI.ValidatorStatus.ACTIVE_EXITING,
-]
-
 PENDING_STATUSES = [
     SchemaBeaconAPI.ValidatorStatus.PENDING_INITIALIZED,
     SchemaBeaconAPI.ValidatorStatus.PENDING_QUEUED,
 ]
 
+ACTIVE_STATUSES = [
+    SchemaBeaconAPI.ValidatorStatus.ACTIVE_ONGOING,
+    SchemaBeaconAPI.ValidatorStatus.ACTIVE_EXITING,
+    SchemaBeaconAPI.ValidatorStatus.ACTIVE_SLASHED,
+]
+
+EXITED_STATUSES = [
+    SchemaBeaconAPI.ValidatorStatus.EXITED_UNSLASHED,
+    SchemaBeaconAPI.ValidatorStatus.EXITED_SLASHED,
+]
+
+WITHDRAWAL_STATUSES = [
+    SchemaBeaconAPI.ValidatorStatus.WITHDRAWAL_POSSIBLE,
+    SchemaBeaconAPI.ValidatorStatus.WITHDRAWAL_DONE,
+]
+
 SLASHED_STATUSES = [
     SchemaBeaconAPI.ValidatorStatus.ACTIVE_SLASHED,
+    SchemaBeaconAPI.ValidatorStatus.EXITED_SLASHED,
 ]
 
 


### PR DESCRIPTION
Track all validator statuses, making it possible to quickly tell how many keys on the connected remote signer are still depositable.

<img width="314" alt="image" src="https://github.com/user-attachments/assets/79ead96d-89c7-4302-b557-1a4f59eec767" />
