### PR TITLE
Do not store empty list when updating sync duties

### DIFF
--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -539,6 +539,10 @@ class SyncCommitteeService(ValidatorDutyService):
                 indices=_validator_indices,
             )
             fetched_duties = response.data
+
+            if len(fetched_duties) == 0:
+                continue
+
             self.sync_duties[sync_period] = fetched_duties
 
             # Schedule sync committee message produce job


### PR DESCRIPTION
Skip further duty processing if the returned list of sync duties is empty