### PR TITLE
Add head block root to HeadBlockRoot tracing event

### DIFF
--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -549,6 +549,7 @@ class MultiBeaconNode:
                     name="HeadBlockRoot",
                     attributes={
                         "host.name": host,
+                        "block_root": block_root,
                     },
                 )
 


### PR DESCRIPTION
In the case of `HeadBlockRoot` events there is no preceding head event emitted by the beacon node, it can therefore be useful to have this information in the high-level trace data.