### PR TITLE
Improve shutdown handling

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -98,12 +98,11 @@ def check_data_dir_permissions(data_dir: Path) -> None:
 
 async def run_services(
     cli_args: CLIArgs,
+    task_manager: TaskManager,
     scheduler: AsyncIOScheduler,
     validator_duty_services: list[ValidatorDutyService],
     shutdown_event: asyncio.Event,
 ) -> None:
-    task_manager = TaskManager()
-
     async with (
         RemoteSigner(url=cli_args.remote_signer_url) as remote_signer,
         MultiBeaconNode(

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -786,7 +786,10 @@ class BeaconNode:
             # Minimal SSE client implementation
             events_iter = aiter(resp.content)
             while True:
-                decoded = (await anext(events_iter)).decode()
+                try:
+                    decoded = (await anext(events_iter)).decode()
+                except StopAsyncIteration:
+                    break
                 if decoded.startswith(":"):
                     self.logger.debug(f"SSE Comment {decoded}")
                     continue

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -2,7 +2,8 @@ import asyncio
 import logging
 import signal
 
-from services import ValidatorDutyService
+from services import BlockProposalService, ValidatorDutyService
+from tasks import TaskManager
 
 _logger = logging.getLogger("vero-shutdown")
 
@@ -11,43 +12,50 @@ async def shut_down(
     validator_duty_services: list[ValidatorDutyService], shutdown_event: asyncio.Event
 ) -> None:
     # Wait for ongoing/upcoming validator duties to be completed
-    services_with_upcoming_duties = [
-        s for s in validator_duty_services if s.has_ongoing_duty or s.has_upcoming_duty
-    ]
-    while len(services_with_upcoming_duties) > 0:
-        service_names = [s.__class__.__name__ for s in services_with_upcoming_duties]
+    # before shutting down
+    block_proposal_service = next(
+        s for s in validator_duty_services if isinstance(s, BlockProposalService)
+    )
+    beacon_chain = block_proposal_service.beacon_chain
+
+    # Wait until there are no upcoming block proposal duties
+    while block_proposal_service.has_upcoming_duty():
+        duty_slot = block_proposal_service.next_duty_slot
+
         _logger.info(
-            f"Waiting for validator duties to be completed for { ', '.join(service_names) }"
+            f"Waiting for upcoming block proposal to complete during slot {duty_slot}"
         )
-        wait_tasks = [
-            asyncio.create_task(s.wait_for_duty_completion())
-            for s in services_with_upcoming_duties
-        ]
-        await asyncio.gather(*wait_tasks)
-        services_with_upcoming_duties = [
-            s
-            for s in validator_duty_services
-            if s.has_ongoing_duty or s.has_upcoming_duty
-        ]
+
+        while duty_slot != beacon_chain.current_slot:
+            _logger.info(f"Waiting for block proposal duty slot ({duty_slot}) to start")
+            await beacon_chain.wait_for_next_slot()
+
+        await block_proposal_service.wait_for_duty_completion()
+
+    # Wait for all duties for the next slot to be complete
+    _logger.info("Waiting for next slot to start")
+    await beacon_chain.wait_for_next_slot()
+    _logger.info("Waiting for duty completion")
+    wait_tasks = [
+        asyncio.create_task(s.wait_for_duty_completion())
+        for s in validator_duty_services
+    ]
+    await asyncio.gather(*wait_tasks)
 
     _logger.info("Shutting down...")
     shutdown_event.set()
-
-
-_shutdown_tasks = set()
 
 
 def shutdown_handler(
     signo: int,
     validator_duty_services: list[ValidatorDutyService],
     shutdown_event: asyncio.Event,
+    task_manager: TaskManager,
 ) -> None:
     _logger.info(f"Received shutdown signal {signal.Signals(signo).name}")
-    task = asyncio.create_task(
+    task_manager.submit_task(
         shut_down(
             validator_duty_services=validator_duty_services,
             shutdown_event=shutdown_event,
         )
     )
-    _shutdown_tasks.add(task)
-    task.add_done_callback(_shutdown_tasks.discard)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -10,28 +10,44 @@ from observability import ErrorType, get_shared_metrics
 
 
 class TaskManager:
-    def __init__(self) -> None:
+    def __init__(self, shutdown_event: asyncio.Event) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(logging.getLogger().level)
+
+        self.shutdown_event = shutdown_event
 
         # asyncio tasks - we store references to them here to prevent them
         #  from being garbage collected
         self._tasks: set[asyncio.Task[Any]] = set()
 
+    def _log_task_exception(self, task: asyncio.Task[Any]) -> None:
+        try:
+            # Re-raise the exception to get a nice traceback
+            task.result()
+        except Exception as e:
+            self.logger.error(
+                f"Task {task} failed with exception {e!r}",
+                exc_info=self.logger.isEnabledFor(logging.DEBUG),
+            )
+            _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
+
     def task_done_callback(self, task: asyncio.Task[Any]) -> None:
-        if task.exception():
-            try:
-                # Re-raise the exception to get a nice traceback
-                task.result()
-            except Exception as e:
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            if not self.shutdown_event.is_set():
+                # Log cancellations as errors only if we're not shutting down
                 self.logger.error(
-                    f"Task {task} failed with exception {e!r}",
+                    f"Task {task} was cancelled",
                     exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
-
-        # Remove the task from the set once it's done
-        self._tasks.discard(task)
+        else:
+            if exc is not None:
+                self._log_task_exception(task)
+        finally:
+            # Remove the task from the set once it's done
+            self._tasks.discard(task)
 
     def submit_task(
         self,
@@ -40,6 +56,11 @@ class TaskManager:
         name: str | None = None,
     ) -> None:
         """Create and track a task from the given coroutine."""
+
+        if self.shutdown_event.is_set():
+            self.logger.debug(f"Cancelling task {name!r}, shutting down...")
+            asyncio.create_task(coro).cancel()
+            return
 
         async def _delayed_coro() -> None:
             if delay > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncGenerator
@@ -127,7 +128,7 @@ async def scheduler(
 
 @pytest.fixture
 def task_manager() -> TaskManager:
-    return TaskManager()
+    return TaskManager(shutdown_event=asyncio.Event())
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously Vero used a defer-shutdown interval approach to determine if it should wait before shutting down, based on the amount of time until the next duty is due (with a higher hardcoded interval for block proposals of 6 seconds).

This PR changes that behavior to the following:

1. Wait for any upcoming block proposal duties to complete, with upcoming meaning within the next 3 slots.
2. Wait for the (attester, sync message) duties to complete in the next slot.
3. Shut down immediately after the duties are finished.

With the new approach, the chance of missing a block proposal because of a restart/update is minimized because of the 3-slot look-ahead interval. The chance of missing an attester/sync message duty is also minimized since Vero will shut down roughly 1/3 into the slot, leaving 2/3 of the slot time for the restart/update.