### PR TITLE
Skip call to `/beacon_committee_subscriptions` with empty list

### DIFF
--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -538,11 +538,12 @@ class AttestationService(ValidatorDutyService):
             if duty.is_aggregator
         ]
 
-        self.task_manager.submit_task(
-            self.multi_beacon_node.prepare_beacon_committee_subscriptions(
-                data=beacon_committee_subscriptions_data,
-            ),
-        )
+        if len(beacon_committee_subscriptions_data) > 0:
+            self.task_manager.submit_task(
+                self.multi_beacon_node.prepare_beacon_committee_subscriptions(
+                    data=beacon_committee_subscriptions_data,
+                ),
+            )
 
         return duties_with_proofs
 


### PR DESCRIPTION
We were unnecessarily making calls to `/eth/v1/validator/beacon_committee_subscriptions` even if there was no aggregator among the managed validators, submitting an empty list.

Some CL clients return a 400 status code if an empty list is submitted.