### PR TITLE
Set `ELECTRA_FORK_EPOCH` for Holesky

### DIFF
--- a/src/spec/configs/holesky.yaml
+++ b/src/spec/configs/holesky.yaml
@@ -39,7 +39,7 @@ DENEB_FORK_EPOCH: 29696
 
 # Electra
 ELECTRA_FORK_VERSION: 0x06017000
-#ELECTRA_FORK_EPOCH: 18446744073709551615  # temporary stub
+ELECTRA_FORK_EPOCH: 115968
 
 # Time parameters
 # ---------------------------------------------------------------

--- a/tests/spec/configs/test_spec_configs.py
+++ b/tests/spec/configs/test_spec_configs.py
@@ -9,6 +9,6 @@ from spec.configs import Network, get_network_spec
 )
 def test_get_network_spec(network: Network) -> None:
     # TODO test currently failing because of missing Electra fork epochs
-    if network in (Network.MAINNET, Network.GNOSIS, Network.HOLESKY):
+    if network in (Network.MAINNET, Network.GNOSIS):
         pytest.xfail("Electra fork epoch not set yet")
     _ = get_network_spec(network=network)


### PR DESCRIPTION
Per https://github.com/ethereum/EIPs/pull/9322 the Electra fork is scheduled for epoch 115968 on the Holešky testnet.