### PR TITLE
Improve typing

### DIFF
--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -526,14 +526,18 @@ class BeaconNode:
             headers={"Eth-Consensus-Version": fork_version.value},
         )
 
-    async def prepare_beacon_committee_subscriptions(self, data: list[dict]) -> None:  # type: ignore[type-arg]
+    async def prepare_beacon_committee_subscriptions(
+        self, data: list[SchemaBeaconAPI.SubscribeToBeaconCommitteeSubnetRequestBody]
+    ) -> None:
         await self._make_request(
             method="POST",
             endpoint="/eth/v1/validator/beacon_committee_subscriptions",
             data=self.json_encoder.encode(data),
         )
 
-    async def prepare_sync_committee_subscriptions(self, data: list[dict]) -> None:  # type: ignore[type-arg]
+    async def prepare_sync_committee_subscriptions(
+        self, data: list[SchemaBeaconAPI.SubscribeToSyncCommitteeSubnetRequestBody]
+    ) -> None:
         await self._make_request(
             method="POST",
             endpoint="/eth/v1/validator/sync_committee_subscriptions",

--- a/src/schemas/beacon_api.py
+++ b/src/schemas/beacon_api.py
@@ -56,6 +56,40 @@ class ForkVersion(Enum):
     ELECTRA = "electra"
 
 
+class AttestationPhase0(msgspec.Struct):
+    aggregation_bits: str
+    data: dict  # type: ignore[type-arg]
+    signature: str
+
+
+class SingleAttestation(msgspec.Struct):
+    committee_index: str
+    attester_index: str
+    data: dict  # type: ignore[type-arg]
+    signature: str
+
+
+class SubscribeToBeaconCommitteeSubnetRequestBody(msgspec.Struct):
+    validator_index: str
+    committee_index: str
+    committees_at_slot: str
+    slot: str
+    is_aggregator: bool
+
+
+class SyncCommitteeSignature(msgspec.Struct):
+    slot: str
+    beacon_block_root: str
+    validator_index: str
+    signature: str
+
+
+class SubscribeToSyncCommitteeSubnetRequestBody(msgspec.Struct):
+    validator_index: str
+    sync_committee_indices: list[str]
+    until_epoch: str
+
+
 class GetAggregatedAttestationV2Response(msgspec.Struct):
     version: ForkVersion
     data: dict  # type: ignore[type-arg]

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -228,7 +228,9 @@ class AttestationService(ValidatorDutyService):
             )
 
             # Sign the attestation data
-            attestations_objects_to_publish: list[dict] = []  # type: ignore[type-arg]
+            attestations_objects_to_publish: list[
+                SchemaBeaconAPI.AttestationPhase0 | SchemaBeaconAPI.SingleAttestation
+            ] = []
 
             def _att_data_for_committee_idx(
                 _orig_att_data_obj: dict,  # type: ignore[type-arg]
@@ -288,7 +290,7 @@ class AttestationService(ValidatorDutyService):
                         aggregation_bits[int(duty.validator_committee_index)] = True
 
                         attestations_objects_to_publish.append(
-                            dict(
+                            SchemaBeaconAPI.AttestationPhase0(
                                 aggregation_bits=aggregation_bits.to_obj(),
                                 data=_att_data_for_committee_idx(
                                     att_data_obj,
@@ -300,7 +302,7 @@ class AttestationService(ValidatorDutyService):
                     elif _fork_version == SchemaBeaconAPI.ForkVersion.ELECTRA:
                         # SingleAttestation object from the CL spec
                         attestations_objects_to_publish.append(
-                            dict(
+                            SchemaBeaconAPI.SingleAttestation(
                                 committee_index=duty.committee_index,
                                 attester_index=duty.validator_index,
                                 data=att_data_obj,
@@ -573,7 +575,7 @@ class AttestationService(ValidatorDutyService):
 
         # Prepare beacon node subnet subscriptions for aggregation duties
         beacon_committee_subscriptions_data = [
-            dict(
+            SchemaBeaconAPI.SubscribeToBeaconCommitteeSubnetRequestBody(
                 validator_index=duty.validator_index,
                 committee_index=duty.committee_index,
                 committees_at_slot=duty.committees_at_slot,

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -181,7 +181,7 @@ class SyncCommitteeService(ValidatorDutyService):
             for validator in sync_committee_members
         ]
 
-        sync_messages_to_publish = []
+        sync_messages_to_publish: list[SchemaBeaconAPI.SyncCommitteeSignature] = []
         for coro in asyncio.as_completed(coroutines):
             try:
                 msg, sig, pubkey = await coro
@@ -194,7 +194,7 @@ class SyncCommitteeService(ValidatorDutyService):
                 continue
 
             sync_messages_to_publish.append(
-                dict(
+                SchemaBeaconAPI.SyncCommitteeSignature(
                     beacon_block_root=msg.sync_committee_message.beacon_block_root,
                     slot=str(msg.sync_committee_message.slot),
                     validator_index=next(
@@ -527,7 +527,7 @@ class SyncCommitteeService(ValidatorDutyService):
                 sync_period + 1
             ) * self.beacon_chain.spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
             sync_committee_subscriptions_data = [
-                dict(
+                SchemaBeaconAPI.SubscribeToSyncCommitteeSubnetRequestBody(
                     validator_index=duty.validator_index,
                     sync_committee_indices=duty.validator_sync_committee_indices,
                     until_epoch=str(until_epoch),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,16 +224,14 @@ async def multi_beacon_node(
 @pytest.fixture(scope="session")
 def genesis(spec: SpecElectra) -> Genesis:
     # Fake genesis 1 hour ago
-    return Genesis.from_obj(  # type: ignore[no-any-return]
-        dict(
-            genesis_time=int(
-                (
-                    datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
-                ).timestamp()
-            ),
-            genesis_validators_root="0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
-            genesis_fork_version=spec.GENESIS_FORK_VERSION,
+    return Genesis(
+        genesis_time=int(
+            (
+                datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
+            ).timestamp()
         ),
+        genesis_validators_root="0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
+        genesis_fork_version=spec.GENESIS_FORK_VERSION,
     )
 
 


### PR DESCRIPTION
The original idea behind using dictionaries was not to hinder attestation performance by creating more complex Python objects. However, benchmarking `msgspec.Struct` vs `dict` showed comparable performance to using dictionaries.

Benchmark: 10,000 identical attestation objects are instantiated, added to a list and encoded. Results (mean over 3 runs):

`dict`: 12.66 seconds
`remerkleable AttestationPhase0 Container`: 17.94 seconds
`msgspec.Struct`: 12.89 seconds