### PR TITLE
Increase `read_bufsize` to be able to handle larger server responses

### DIFF
--- a/src/observability/_metrics_shared.py
+++ b/src/observability/_metrics_shared.py
@@ -20,6 +20,7 @@ class ErrorType(Enum):
     DUTIES_UPDATE = "duties-update"
     VALIDATOR_STATUS_UPDATE = "validator-status-update"
     SIGNATURE = "signature"
+    EVENT_CONSUMER = "event-consumer"
     OTHER = "other"
 
 

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -17,7 +17,12 @@ from prometheus_client import Gauge, Histogram
 from remerkleable.complex import Container
 from yarl import URL
 
-from observability import get_service_name, get_service_version
+from observability import (
+    ErrorType,
+    get_service_name,
+    get_service_version,
+    get_shared_metrics,
+)
 from observability.api_client import RequestLatency, ServiceType
 from schemas import SchemaBeaconAPI, SchemaRemoteSigner, SchemaValidator
 from spec import Spec, SpecAttestation, SpecSyncCommittee
@@ -61,6 +66,7 @@ _BEACON_NODE_EXECUTION_PAYLOAD_VALUE = Histogram(
     labelnames=["host"],
     buckets=_block_value_buckets,
 )
+(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class BeaconNodeNotReady(Exception):
@@ -121,6 +127,9 @@ class BeaconNode:
             trace_configs=[
                 RequestLatency(host=self.host, service_type=ServiceType.BEACON_NODE),
             ],
+            # Default aiohttp read buffer is only 64KB which is not always enough,
+            # resulting in ValueError("Chunk too big")
+            read_bufsize=2**19,
         )
 
         self.json_encoder = msgspec.json.Encoder()
@@ -826,6 +835,9 @@ class BeaconNode:
                 try:
                     event_name = decoded.split(":")[1].strip()
                 except Exception as e:
+                    _ERRORS_METRIC.labels(
+                        error_type=ErrorType.EVENT_CONSUMER.value,
+                    ).inc()
                     self.logger.error(
                         f"Failed to parse event name from {decoded} ({e!r}) -> ignoring event...",
                         exc_info=self.logger.isEnabledFor(logging.DEBUG),

--- a/src/providers/remote_signer.py
+++ b/src/providers/remote_signer.py
@@ -87,6 +87,9 @@ class RemoteSigner:
                     service_type=ServiceType.REMOTE_SIGNER,
                 ),
             ],
+            # Default aiohttp read buffer is only 64KB which is not always enough,
+            # resulting in ValueError("Chunk too big")
+            read_bufsize=2**19,
         )
 
         self.high_priority_client_session = aiohttp.ClientSession(
@@ -98,6 +101,9 @@ class RemoteSigner:
                     service_type=ServiceType.REMOTE_SIGNER,
                 ),
             ],
+            # Default aiohttp read buffer is only 64KB which is not always enough,
+            # resulting in ValueError("Chunk too big")
+            read_bufsize=2**19,
         )
 
         self.json_encoder = msgspec.json.Encoder()


### PR DESCRIPTION
During the post-Pectra recovery on Holesky, some of the SSE stream events were not parsed correctly due to them being too big for aiohttp's `StreamReader`. This MR increases the buffer size from the default 64KB to a more generous 512KB, allowing Vero to process the larger slashing SSE events occurring on Holesky.