### PR TITLE
Add `----DANGER----disable-slashing-detection` CLI flag

### DIFF
--- a/docs/running_vero.md
+++ b/docs/running_vero.md
@@ -146,3 +146,16 @@ ___
 #### `--log-level`
 
 The logging level to use, one of `CRITICAL,ERROR,WARNING,INFO,DEBUG`. Defaults to `INFO`.
+___
+
+#### `----DANGER----disable-slashing-detection`
+
+**_!!! This flag is extremely dangerous and should not be provided to Vero under normal circumstances!!!_**
+
+**_Do not provide this flag unless you fully understand its implications!_**
+
+Disables Vero's proactive slashing detection.
+
+With this flag provided, Vero will keep attesting and producing blocks
+even if it detects some of its managed validators have been slashed.
+___

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -119,7 +119,10 @@ class AttestationService(ValidatorDutyService):
         slot: int,
         head_event: SchemaBeaconAPI.HeadEvent | None = None,
     ) -> None:
-        if self.validator_status_tracker_service.slashing_detected:
+        if (
+            self.validator_status_tracker_service.slashing_detected
+            and not self.cli_args.disable_slashing_detection
+        ):
             raise RuntimeError("Slashing detected, not attesting")
 
         if slot <= self._last_slot_duty_started_for:

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -242,7 +242,10 @@ class BlockProposalService(ValidatorDutyService):
             )
 
     async def propose_block(self, slot: int) -> None:
-        if self.validator_status_tracker_service.slashing_detected:
+        if (
+            self.validator_status_tracker_service.slashing_detected
+            and not self.cli_args.disable_slashing_detection
+        ):
             raise RuntimeError("Slashing detected, not producing block")
 
         if slot <= self._last_slot_duty_started_for:

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -93,11 +93,6 @@ class SyncCommitteeService(ValidatorDutyService):
         duty_slot: int,
         head_event: SchemaBeaconAPI.HeadEvent | None = None,
     ) -> None:
-        if self.validator_status_tracker_service.slashing_detected:
-            raise RuntimeError(
-                "Slashing detected, not producing sync committee message",
-            )
-
         # Using < and not <= on purpose: if a head event comes in late,
         # we still want to produce a sync message for that block root too
         # since it is not slashable to publish 2 different sync messages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def cli_args(
         metrics_port=8000,
         metrics_multiprocess_mode=False,
         log_level="INFO",
+        disable_slashing_detection=False,
     )
 
 


### PR DESCRIPTION
Adds a flag that disables Vero's proactive slashing detection. If the flag is provided, Vero continues performing duties even if some of its managed validators have been slashed.