### PR TITLE
Indicate Vero is ready for Electra in logs

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -18,7 +18,8 @@ from services import (
     ValidatorDutyServiceOptions,
     ValidatorStatusTrackerService,
 )
-from spec import Spec, SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec.base import SpecElectra
 from spec.configs import get_network_spec
 from tasks import TaskManager
 
@@ -97,7 +98,7 @@ def check_data_dir_permissions(data_dir: Path) -> None:
         )
 
 
-def load_spec(cli_args: CLIArgs) -> Spec:
+def load_spec(cli_args: CLIArgs) -> SpecElectra:
     spec = get_network_spec(
         network=cli_args.network,
         network_custom_config_path=cli_args.network_custom_config_path,

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -29,9 +29,9 @@ from observability import (
 )
 from observability.api_client import RequestLatency, ServiceType
 from schemas import SchemaBeaconAPI, SchemaRemoteSigner, SchemaValidator
-from spec import Spec, SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
 from spec.attestation import AttestationData
-from spec.base import Genesis, parse_spec
+from spec.base import Genesis, SpecElectra, parse_spec
 from spec.constants import INTERVALS_PER_SLOT
 from tasks import TaskManager
 
@@ -106,7 +106,7 @@ class BeaconNode:
     def __init__(
         self,
         base_url: str,
-        spec: Spec,
+        spec: SpecElectra,
         scheduler: AsyncIOScheduler,
         task_manager: TaskManager,
     ) -> None:
@@ -296,7 +296,7 @@ class BeaconNode:
         )
         return Genesis.from_obj(json.loads(resp)["data"])  # type: ignore[no-any-return]
 
-    async def get_spec(self) -> Spec:
+    async def get_spec(self) -> SpecElectra:
         resp = await self._make_request(
             method="GET",
             endpoint="/eth/v1/config/spec",

--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -51,8 +51,9 @@ from args import CLIArgs
 from observability import ErrorType, get_shared_metrics
 from providers import BeaconNode
 from schemas import SchemaBeaconAPI, SchemaValidator
-from spec import Spec, SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
 from spec.attestation import AttestationData
+from spec.base import SpecElectra
 from spec.configs import Network
 from spec.constants import INTERVALS_PER_SLOT
 from tasks import TaskManager
@@ -74,7 +75,7 @@ class MultiBeaconNode:
         self,
         beacon_node_urls: list[str],
         beacon_node_urls_proposal: list[str],
-        spec: Spec,
+        spec: SpecElectra,
         scheduler: AsyncIOScheduler,
         task_manager: TaskManager,
         cli_args: CLIArgs,

--- a/src/spec/__init__.py
+++ b/src/spec/__init__.py
@@ -1,10 +1,8 @@
 from .attestation import SpecAttestation
-from .base import Spec
 from .block import SpecBeaconBlock
 from .sync_committee import SpecSyncCommittee
 
 __all__ = [
-    "Spec",
     "SpecAttestation",
     "SpecBeaconBlock",
     "SpecSyncCommittee",

--- a/src/spec/attestation.py
+++ b/src/spec/attestation.py
@@ -13,7 +13,7 @@ from spec.common import (
 )
 
 if TYPE_CHECKING:
-    from spec import Spec
+    from spec.base import SpecElectra
 
 
 class CommitteeIndex(UInt64SerializedAsString):
@@ -48,7 +48,7 @@ class SpecAttestation:
     @classmethod
     def initialize(
         cls,
-        spec: "Spec",
+        spec: "SpecElectra",
     ) -> None:
         class AttestationPhase0(Container):
             aggregation_bits: Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE]

--- a/src/spec/base.py
+++ b/src/spec/base.py
@@ -107,5 +107,5 @@ class SpecElectra(SpecDeneb):
     MAX_ATTESTER_SLASHINGS_ELECTRA: uint64
 
 
-def parse_spec(data: dict[str, str]) -> Spec:
+def parse_spec(data: dict[str, str]) -> SpecElectra:
     return SpecElectra.from_obj(data)

--- a/src/spec/configs/__init__.py
+++ b/src/spec/configs/__init__.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from pathlib import Path
 
-from spec.base import Spec, parse_spec
+from spec.base import SpecElectra, parse_spec
 
 
 class Network(Enum):
@@ -37,7 +37,7 @@ def parse_yaml_file(fp: Path) -> dict[str, str]:
 
 def get_network_spec(
     network: Network, network_custom_config_path: str | None = None
-) -> Spec:
+) -> SpecElectra:
     spec_dict = {}
 
     if network == Network.CUSTOM:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from schemas import SchemaBeaconAPI
 from schemas.beacon_api import ForkVersion
 from schemas.validator import ACTIVE_STATUSES, ValidatorIndexPubkey
 from services import ValidatorStatusTrackerService
-from spec import Spec, SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
 from spec.base import SpecElectra, Fork, Genesis, Version
 from spec.common import Epoch
 from spec.configs import Network, get_network_spec
@@ -77,7 +77,7 @@ def _init_observability() -> None:
 
 
 @pytest.fixture(scope="session")
-def spec(request: pytest.FixtureRequest) -> Spec:
+def spec(request: pytest.FixtureRequest) -> SpecElectra:
     return get_network_spec(network=Network._TESTS)
 
 


### PR DESCRIPTION
Adds an Electra-readiness indicator log line on Vero initialization and at the start of every epoch:

```
BeaconChain          - INFO : Ready for Electra at epoch XXX
```