### PR TITLE
Add support for the Keymanager API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
           [
           aiohttp==3.11.16,
           msgspec==0.19.0,
+          prometheus-client==0.21.1,
           pytest==8.3.5,
           remerkleable==0.1.28,
           ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV PROMETHEUS_MULTIPROC_DIR=/tmp/multiprocessing
 
 COPY --chown=vero:vero src .
 
-EXPOSE 8000
+EXPOSE 8000 8001
 
 ARG GIT_TAG
 ARG GIT_COMMIT

--- a/docs/running_vero.md
+++ b/docs/running_vero.md
@@ -66,7 +66,13 @@ ___
 
 #### `--remote-signer-url`
 
-**[required]** URL of the remote signer, e.g. `http://remote-signer:9000`
+URL of the remote signer, e.g. `http://remote-signer:9000`.
+If provided, Vero automatically handles duties for all validator keys
+present on the remote signer.
+
+_Note: This flag is mutually exclusive with `--enable-keymanager-api`.
+One of these flags must be provided to server as a source of validator
+keys._
 ___
 
 #### `--beacon-node-urls`
@@ -126,11 +132,20 @@ ___
 #### `--fee-recipient`
 
 **[required]** The fee recipient address to use during block proposals.
+
+Can be set individually for each validator through the Keymanager API.
+___
+
+#### `--data-dir`
+
+The directory to use for storing persistent data. Defaults to `/vero/data`.
 ___
 
 #### `--graffiti`
 
 The graffiti string to use during block proposals. Defaults to an empty string.
+
+Can be set individually for each validator through the Keymanager API.
 ___
 
 #### `--gas-limit`
@@ -152,6 +167,7 @@ Defaults to the following values::
 | chiado   |   17000000 |
 | custom   |  100000000 |
 
+Can be set individually for each validator through the Keymanager API.
 ___
 
 #### `--use-external-builder`
@@ -169,9 +185,33 @@ Defaults to `90`, meaning the externally built block must be approximately
 11% more valuable to be chosen over a locally built block.
 ___
 
-#### `--data-dir`
+#### `--enable-keymanager-api`
 
-The directory to use for storing persistent data. Defaults to `/vero/data`.
+Enables the Keymanager API.
+
+_Note: This flag is mutually exclusive with `--remote-signer-url`.
+One of these flags must be provided to server as a source of validator
+keys._
+___
+
+#### `--keymanager-api-token-file-path`
+
+Path to a file containing the bearer token used for Keymanager API
+authentication. If none is provided, a file called
+`keymanager-api-token.txt` will be created in Vero's data directory.
+
+___
+
+#### `--keymanager-api-address`
+
+The Keymanager API server listen address. Defaults to `localhost`.
+
+___
+
+#### `--keymanager-api-port`
+
+The Keymanager API server port number. Defaults to `8001`.
+
 ___
 
 #### `--metrics-address`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "milagro-bls-binding>=1.9.0",
     "pre-commit>=4.1.0",
     "pytest>=8.3.5",
+    "pytest-aiohttp>=1.1.0",
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,6 +40,7 @@ aiohttp==3.11.16 \
     --hash=sha256:fd36c119c5d6551bce374fcb5c19269638f8d09862445f85a5a48596fd59f4bb
     # via
     #   aioresponses
+    #   pytest-aiohttp
     #   vero
 aioresponses==0.7.8 \
     --hash=sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94 \
@@ -443,11 +444,16 @@ pytest==8.3.5 \
     --hash=sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820 \
     --hash=sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845
     # via
+    #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-cov
+pytest-aiohttp==1.1.0 \
+    --hash=sha256:147de8cb164f3fc9d7196967f109ab3c0b93ea3463ab50631e56438eab7b5adc \
+    --hash=sha256:f39a11693a0dce08dd6c542d241e199dd8047a6e6596b2bcfa60d373f143456d
 pytest-asyncio==0.26.0 \
     --hash=sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0 \
     --hash=sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
+    # via pytest-aiohttp
 pytest-cov==6.1.1 \
     --hash=sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a \
     --hash=sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde

--- a/src/api/keymanager/__init__.py
+++ b/src/api/keymanager/__init__.py
@@ -1,0 +1,3 @@
+from .api import start_server
+
+__all__ = ["start_server"]

--- a/src/api/keymanager/api.py
+++ b/src/api/keymanager/api.py
@@ -54,9 +54,7 @@ async def start_server(keymanager: "Keymanager", cli_args: CLIArgs) -> None:
     app = _create_app(keymanager=keymanager, cli_args=cli_args)
     logger = logging.getLogger("api.keymanager.api")
     try:
-        runner = web.AppRunner(
-            app,
-        )
+        runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(
             runner,

--- a/src/api/keymanager/api.py
+++ b/src/api/keymanager/api.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from args import CLIArgs
+
+from .fee_recipient_endpoints import routes as fee_recipient_routes
+from .gas_limit_endpoints import routes as gas_limit_routes
+from .graffiti_endpoints import routes as graffiti_routes
+from .middlewares import bearer_authentication, exception_handler
+from .remote_key_manager_endpoints import routes as remote_key_manager_routes
+from .voluntary_exit_endpoints import routes as voluntary_exit_routes
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+
+def _get_bearer_token_value(cli_args: CLIArgs) -> str:
+    # Check if the filepath exists - if it does, read the token value from it
+    fp = cli_args.keymanager_api_token_file_path
+    if fp.exists():
+        with Path.open(fp) as f:
+            return f.read().strip()
+
+    # If it doesn't, generate a value and store it in the file.
+    bearer_token_value = os.urandom(32).hex()[2:]
+    with Path.open(fp, "w") as f:
+        f.write(bearer_token_value)
+
+    return bearer_token_value
+
+
+def _create_app(keymanager: "Keymanager", cli_args: CLIArgs) -> web.Application:
+    app = web.Application(middlewares=[bearer_authentication, exception_handler])
+
+    app["bearer_token"] = _get_bearer_token_value(cli_args=cli_args)
+    app["keymanager"] = keymanager
+
+    app.add_routes(fee_recipient_routes)
+    app.add_routes(gas_limit_routes)
+    app.add_routes(graffiti_routes)
+    app.add_routes(remote_key_manager_routes)
+    app.add_routes(voluntary_exit_routes)
+
+    return app
+
+
+async def start_server(keymanager: "Keymanager", cli_args: CLIArgs) -> None:
+    app = _create_app(keymanager=keymanager, cli_args=cli_args)
+    logger = logging.getLogger("api.keymanager.api")
+    try:
+        runner = web.AppRunner(
+            app,
+        )
+        await runner.setup()
+        site = web.TCPSite(
+            runner,
+            host=cli_args.keymanager_api_address,
+            port=cli_args.keymanager_api_port,
+        )
+        logger.info(
+            f"Starting Keymanager API on {cli_args.keymanager_api_address}:{cli_args.keymanager_api_port}"
+        )
+        await site.start()
+
+        # run forever by 1 hour intervals,
+        while True:  # noqa: ASYNC110
+            await asyncio.sleep(3600)
+
+    except asyncio.CancelledError:
+        logger.debug("Shutting down")
+        await app.shutdown()
+        await app.cleanup()
+
+    except Exception as e:
+        logger.error(
+            f"Unexpected error occurred - exiting... {e!r}",
+            exc_info=logger.isEnabledFor(logging.DEBUG),
+        )
+        sys.exit(1)

--- a/src/api/keymanager/fee_recipient_endpoints.py
+++ b/src/api/keymanager/fee_recipient_endpoints.py
@@ -1,0 +1,53 @@
+"""
+Implements the Keymanager API Fee Recipient endpoints.
+https://ethereum.github.io/keymanager-APIs
+"""
+
+from typing import TYPE_CHECKING
+
+import msgspec.json
+from aiohttp import web
+
+from schemas import SchemaKeymanagerAPI
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/eth/v1/validator/{pubkey}/feerecipient")
+async def fee_recipient_get(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    resp = SchemaKeymanagerAPI.ListFeeRecipientResponse(
+        data=keymanager.get_fee_recipient(pubkey)
+    )
+
+    return web.json_response(body=msgspec.json.encode(resp))
+
+
+@routes.post("/eth/v1/validator/{pubkey}/feerecipient")
+async def fee_recipient_post(request: web.Request) -> web.Response:
+    request_data = msgspec.json.decode(
+        await request.content.read(),
+        type=SchemaKeymanagerAPI.SetFeeRecipientRequest,
+    )
+
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    keymanager.set_fee_recipient(pubkey=pubkey, fee_recipient=request_data.ethaddress)
+
+    return web.Response(status=202)
+
+
+@routes.delete("/eth/v1/validator/{pubkey}/feerecipient")
+async def fee_recipient_delete(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    keymanager.delete_configured_fee_recipient(pubkey=pubkey)
+
+    return web.Response(status=204)

--- a/src/api/keymanager/gas_limit_endpoints.py
+++ b/src/api/keymanager/gas_limit_endpoints.py
@@ -1,0 +1,52 @@
+"""
+Implements the Keymanager API Gas Limit endpoints.
+https://ethereum.github.io/keymanager-APIs
+"""
+
+from typing import TYPE_CHECKING
+
+import msgspec.json
+from aiohttp import web
+
+from schemas import SchemaKeymanagerAPI
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/eth/v1/validator/{pubkey}/gas_limit")
+async def gas_limit_get(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    resp = SchemaKeymanagerAPI.ListGasLimitResponse(
+        data=keymanager.get_gas_limit(pubkey)
+    )
+
+    return web.json_response(body=msgspec.json.encode(resp))
+
+
+@routes.post("/eth/v1/validator/{pubkey}/gas_limit")
+async def gas_limit_post(request: web.Request) -> web.Response:
+    request_data = msgspec.json.decode(
+        await request.content.read(), type=SchemaKeymanagerAPI.SetGasLimitRequest
+    )
+
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    keymanager.set_gas_limit(pubkey=pubkey, gas_limit=request_data.gas_limit)
+
+    return web.Response(status=202)
+
+
+@routes.delete("/eth/v1/validator/{pubkey}/gas_limit")
+async def gas_limit_delete(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    keymanager.delete_configured_gas_limit(pubkey=pubkey)
+
+    return web.Response(status=204)

--- a/src/api/keymanager/graffiti_endpoints.py
+++ b/src/api/keymanager/graffiti_endpoints.py
@@ -1,0 +1,53 @@
+"""
+Implements the Keymanager API Graffiti endpoints.
+https://ethereum.github.io/keymanager-APIs
+"""
+
+from typing import TYPE_CHECKING
+
+import msgspec.json
+from aiohttp import web
+
+from schemas import SchemaKeymanagerAPI
+from spec.utils import encode_graffiti
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/eth/v1/validator/{pubkey}/graffiti")
+async def graffiti_get(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    resp = SchemaKeymanagerAPI.GraffitiResponse(data=keymanager.get_graffiti(pubkey))
+
+    return web.json_response(body=msgspec.json.encode(resp))
+
+
+@routes.post("/eth/v1/validator/{pubkey}/graffiti")
+async def graffiti_post(request: web.Request) -> web.Response:
+    request_data = msgspec.json.decode(
+        await request.content.read(), type=SchemaKeymanagerAPI.SetGraffitiRequest
+    )
+
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    # Check if it can be encoded within 32 bytes
+    _ = encode_graffiti(request_data.graffiti)
+
+    keymanager.set_graffiti(pubkey=pubkey, graffiti=request_data.graffiti)
+    return web.Response(status=202)
+
+
+@routes.delete("/eth/v1/validator/{pubkey}/graffiti")
+async def graffiti_delete(request: web.Request) -> web.Response:
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    keymanager.delete_configured_graffiti_value(pubkey=pubkey)
+
+    return web.Response(status=204)

--- a/src/api/keymanager/middlewares.py
+++ b/src/api/keymanager/middlewares.py
@@ -1,0 +1,66 @@
+import logging
+from collections.abc import Awaitable, Callable
+
+import msgspec
+from aiohttp import hdrs, web
+
+from providers.keymanager import PubkeyNotFound
+from schemas.keymanager_api import ErrorResponse
+
+
+@web.middleware
+async def bearer_authentication(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    auth_header_value = request.headers.get(hdrs.AUTHORIZATION)
+    if not auth_header_value:
+        return web.json_response(
+            status=401,
+            body=msgspec.json.encode(
+                ErrorResponse(message="No value provided for Authorization header")
+            ),
+        )
+
+    if auth_header_value != f"Bearer {request.app['bearer_token']}":
+        return web.json_response(
+            status=403,
+            body=msgspec.json.encode(
+                ErrorResponse(message="Invalid value provided for Authorization header")
+            ),
+        )
+
+    return await handler(request)
+
+
+@web.middleware
+async def exception_handler(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    """
+    Transforms any exception the app may raise into a JSON response
+    to comply with the Keymanager API specification.
+    """
+    try:
+        return await handler(request)
+    except web.HTTPException:
+        raise
+    except msgspec.ValidationError as e:
+        status_code = 400
+        msg = repr(e)
+    except PubkeyNotFound as e:
+        status_code = 500
+        msg = repr(e)
+    except Exception as e:
+        status_code = 500
+        msg = repr(e)
+        logger = logging.getLogger("api.keymanager.middlewares.exception_handler")
+        logger.error(
+            f"Exception occurred while handling request to {request.url}: {msg}",
+            exc_info=logger.isEnabledFor(logging.DEBUG),
+        )
+
+    return web.json_response(
+        status=status_code, body=msgspec.json.encode(ErrorResponse(message=msg))
+    )

--- a/src/api/keymanager/remote_key_manager_endpoints.py
+++ b/src/api/keymanager/remote_key_manager_endpoints.py
@@ -1,0 +1,76 @@
+"""
+Implements the Keymanager API Remote Key Manager endpoints.
+https://ethereum.github.io/keymanager-APIs
+"""
+
+from typing import TYPE_CHECKING
+
+import msgspec.json
+from aiohttp import web
+
+from schemas import SchemaKeymanagerAPI
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/eth/v1/remotekeys")
+async def remote_keys_get(request: web.Request) -> web.Response:
+    keymanager: Keymanager = request.app["keymanager"]
+
+    remote_keys = SchemaKeymanagerAPI.ListRemoteKeysResponse(
+        data=[
+            SchemaKeymanagerAPI.RemoteKeyWithReadOnlyStatus(
+                pubkey=remote_key.pubkey,
+                url=remote_key.url,
+                readonly=False,
+            )
+            for remote_key in keymanager.list_remote_keys()
+        ]
+    )
+
+    return web.json_response(body=msgspec.json.encode(remote_keys))
+
+
+@routes.post("/eth/v1/remotekeys")
+async def remote_keys_post(request: web.Request) -> web.Response:
+    request_data = msgspec.json.decode(
+        await request.content.read(),
+        type=SchemaKeymanagerAPI.ImportRemoteKeysRequest,
+    )
+
+    keymanager: Keymanager = request.app["keymanager"]
+    import_status_messages = await keymanager.import_remote_keys(
+        remote_keys=request_data.remote_keys
+    )
+
+    return web.json_response(
+        body=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysResponse(
+                data=import_status_messages,
+            )
+        ),
+    )
+
+
+@routes.delete("/eth/v1/remotekeys")
+async def remote_keys_delete(request: web.Request) -> web.Response:
+    request_data = msgspec.json.decode(
+        await request.content.read(),
+        type=SchemaKeymanagerAPI.DeleteRemoteKeysRequest,
+    )
+
+    keymanager: Keymanager = request.app["keymanager"]
+    delete_status_messages = await keymanager.delete_remote_keys(
+        pubkeys=request_data.pubkeys
+    )
+
+    return web.json_response(
+        body=msgspec.json.encode(
+            SchemaKeymanagerAPI.DeleteRemoteKeysResponse(
+                data=delete_status_messages,
+            )
+        ),
+    )

--- a/src/api/keymanager/voluntary_exit_endpoints.py
+++ b/src/api/keymanager/voluntary_exit_endpoints.py
@@ -1,0 +1,36 @@
+"""
+Implements the Keymanager API Voluntary Exit endpoints.
+https://ethereum.github.io/keymanager-APIs
+"""
+
+from typing import TYPE_CHECKING
+
+import msgspec.json
+from aiohttp import web
+
+from schemas import SchemaKeymanagerAPI
+
+if TYPE_CHECKING:
+    from providers import Keymanager
+
+routes = web.RouteTableDef()
+
+
+@routes.post("/eth/v1/validator/{pubkey}/voluntary_exit")
+async def voluntary_exit_post(request: web.Request) -> web.Response:
+    # Minimum epoch for processing exit. Defaults to the current epoch if not set.
+    epoch = request.query.get("epoch")
+
+    pubkey = request.match_info["pubkey"]
+    keymanager: Keymanager = request.app["keymanager"]
+
+    signed_voluntary_exit = await keymanager.sign_voluntary_exit_message(
+        pubkey=pubkey,
+        epoch=int(epoch) if epoch else None,
+    )
+
+    return web.json_response(
+        body=msgspec.json.encode(
+            SchemaKeymanagerAPI.SignVoluntaryExitResponse(data=signed_voluntary_exit)
+        )
+    )

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -239,3 +239,7 @@ async def run_services(
         await monitor_event_loop(
             beacon_chain=beacon_chain, shutdown_event=shutdown_event
         )
+
+        # Reaching this point means the shutdown_event was set
+        # -> cancel all pending tasks
+        task_manager.cancel_all()

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -7,7 +7,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs
 from observability.event_loop import monitor_event_loop
-from providers import BeaconChain, MultiBeaconNode, RemoteSigner
+from providers import DB, BeaconChain, MultiBeaconNode, RemoteSigner
 from schemas import SchemaBeaconAPI
 from services import (
     AttestationService,
@@ -157,6 +157,9 @@ async def run_services(
             validator_status_tracker_service.on_new_slot
         )
         _logger.info("Initialized validator status tracker")
+
+        db = DB(data_dir=cli_args.data_dir)
+        db.run_migrations()
 
         validator_service_args = ValidatorDutyServiceOptions(
             multi_beacon_node=multi_beacon_node,

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -1,13 +1,21 @@
 import asyncio
+import contextlib
 import logging
 import time
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs
 from observability.event_loop import monitor_event_loop
-from providers import DB, BeaconChain, MultiBeaconNode, RemoteSigner
+from providers import (
+    DB,
+    BeaconChain,
+    Keymanager,
+    MultiBeaconNode,
+    RemoteSigner,
+)
 from schemas import SchemaBeaconAPI
 from services import (
     AttestationService,
@@ -121,17 +129,21 @@ async def run_services(
 ) -> None:
     spec = load_spec(cli_args=cli_args)
 
-    async with (
-        RemoteSigner(url=cli_args.remote_signer_url) as remote_signer,
-        MultiBeaconNode(
-            beacon_node_urls=cli_args.beacon_node_urls,
-            beacon_node_urls_proposal=cli_args.beacon_node_urls_proposal,
-            spec=spec,
-            scheduler=scheduler,
-            task_manager=task_manager,
-            cli_args=cli_args,
-        ) as multi_beacon_node,
-    ):
+    db = DB(data_dir=cli_args.data_dir)
+    db.run_migrations()
+
+    async with contextlib.AsyncExitStack() as exit_stack:
+        multi_beacon_node = await exit_stack.enter_async_context(
+            MultiBeaconNode(
+                beacon_node_urls=cli_args.beacon_node_urls,
+                beacon_node_urls_proposal=cli_args.beacon_node_urls_proposal,
+                spec=spec,
+                scheduler=scheduler,
+                task_manager=task_manager,
+                cli_args=cli_args,
+            )
+        )
+
         beacon_chain = BeaconChain(
             spec=spec,
             genesis=multi_beacon_node.best_beacon_node.genesis,
@@ -140,15 +152,38 @@ async def run_services(
         await _wait_for_genesis(
             genesis_timestamp=beacon_chain.get_timestamp_for_slot(0)
         )
-        beacon_chain.start_slot_ticker()
+
+        process_pool_executor = ProcessPoolExecutor()
+        keymanager = Keymanager(
+            db=db,
+            beacon_chain=beacon_chain,
+            multi_beacon_node=multi_beacon_node,
+            cli_args=cli_args,
+            process_pool_executor=process_pool_executor,
+        )
+        signature_provider: Keymanager | RemoteSigner
+        if cli_args.enable_keymanager_api:
+            signature_provider = await exit_stack.enter_async_context(keymanager)
+        else:
+            if cli_args.remote_signer_url is None:
+                raise RuntimeError(
+                    "remote_signer_url is None despite disabled Keymanager API"
+                )
+            signature_provider = await exit_stack.enter_async_context(
+                RemoteSigner(
+                    url=cli_args.remote_signer_url,
+                    process_pool_executor=process_pool_executor,
+                )
+            )
 
         _logger.info(f"Current epoch: {beacon_chain.current_epoch}")
         _logger.info(f"Current slot: {beacon_chain.current_slot}")
+        beacon_chain.start_slot_ticker()
 
         validator_status_tracker_service = ValidatorStatusTrackerService(
             multi_beacon_node=multi_beacon_node,
             beacon_chain=beacon_chain,
-            remote_signer=remote_signer,
+            signature_provider=signature_provider,
             scheduler=scheduler,
             task_manager=task_manager,
         )
@@ -158,13 +193,11 @@ async def run_services(
         )
         _logger.info("Initialized validator status tracker")
 
-        db = DB(data_dir=cli_args.data_dir)
-        db.run_migrations()
-
         validator_service_args = ValidatorDutyServiceOptions(
             multi_beacon_node=multi_beacon_node,
             beacon_chain=beacon_chain,
-            remote_signer=remote_signer,
+            signature_provider=signature_provider,
+            keymanager=keymanager,
             validator_status_tracker_service=validator_status_tracker_service,
             scheduler=scheduler,
             cli_args=cli_args,

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 from shutdown import shutdown_handler
 
 
-async def main(cli_args: CLIArgs) -> None:
+async def main(cli_args: CLIArgs, shutdown_event: asyncio.Event) -> None:
     logging.getLogger("vero-init").info(
         f"Starting vero {get_service_version()} (commit {get_service_commit()})",
     )
@@ -37,7 +37,7 @@ async def main(cli_args: CLIArgs) -> None:
 
     validator_duty_services: list[ValidatorDutyService] = []
 
-    shutdown_event = asyncio.Event()
+    shutdown_event = shutdown_event
     task_manager = TaskManager(shutdown_event=shutdown_event)
 
     loop = asyncio.get_running_loop()
@@ -72,4 +72,4 @@ if __name__ == "__main__":
         log_level=cli_args.log_level,
     )
     log_cli_arg_values(cli_args)
-    asyncio.run(main(cli_args=cli_args))
+    asyncio.run(main(cli_args=cli_args, shutdown_event=asyncio.Event()))

--- a/src/main.py
+++ b/src/main.py
@@ -19,23 +19,11 @@ if TYPE_CHECKING:
 from shutdown import shutdown_handler
 
 
-def prep_datadir(data_dir: Path) -> None:
-    # Write to placeholder file
-    # so datadir is not empty.
-    # The data dir is not necessary at the
-    # moment but will be used soon for
-    # another laying of slashing protection
-    # and caching.
-    with Path.open(data_dir / "vero_placeholder.yml", "w") as f:
-        f.write("placeholder")
-
-
 async def main(cli_args: CLIArgs) -> None:
     logging.getLogger("vero-init").info(
         f"Starting vero {get_service_version()} (commit {get_service_commit()})",
     )
     check_data_dir_permissions(data_dir=Path(cli_args.data_dir))
-    prep_datadir(data_dir=Path(cli_args.data_dir))
 
     scheduler = AsyncIOScheduler(
         timezone=datetime.UTC,

--- a/src/observability/_metrics.py
+++ b/src/observability/_metrics.py
@@ -21,6 +21,6 @@ def setup_metrics(addr: str, port: int, multiprocess_mode: bool = False) -> None
         for file in _multiprocessing_data_path.iterdir():
             Path.unlink(_multiprocessing_data_dir / file)
 
-        multiprocess.MultiProcessCollector(REGISTRY)
+        multiprocess.MultiProcessCollector(REGISTRY)  # type: ignore[no-untyped-call]
 
     start_http_server(addr=addr, port=port)

--- a/src/observability/_metrics_shared.py
+++ b/src/observability/_metrics_shared.py
@@ -3,7 +3,7 @@ from enum import Enum
 from prometheus_client import Counter
 
 _ERRORS_METRIC: Counter | None = None
-_METRICS_INITIATED = False
+_METRICS_INITIALIZED = False
 
 
 class ErrorType(Enum):
@@ -25,9 +25,9 @@ class ErrorType(Enum):
 
 
 def get_shared_metrics() -> tuple[Counter]:
-    global _ERRORS_METRIC, _METRICS_INITIATED
+    global _ERRORS_METRIC, _METRICS_INITIALIZED
 
-    if not _METRICS_INITIATED:
+    if not _METRICS_INITIALIZED:
         _ERRORS_METRIC = Counter(
             "errors",
             "Number of errors",
@@ -36,6 +36,9 @@ def get_shared_metrics() -> tuple[Counter]:
         for enum_type in ErrorType:
             _ERRORS_METRIC.labels(enum_type.value).reset()
 
-        _METRICS_INITIATED = True
+        _METRICS_INITIALIZED = True
+
+    if _ERRORS_METRIC is None:
+        raise ValueError("_ERRORS_METRIC must be initialized")
 
     return (_ERRORS_METRIC,)

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,9 +1,11 @@
 from .beacon_chain import BeaconChain
 from .beacon_node import BeaconNode
+from .db.db import DB
 from .multi_beacon_node import MultiBeaconNode
 from .remote_signer import RemoteSigner
 
 __all__ = [
+    "DB",
     "BeaconChain",
     "BeaconNode",
     "MultiBeaconNode",

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,13 +1,17 @@
 from .beacon_chain import BeaconChain
 from .beacon_node import BeaconNode
 from .db.db import DB
+from .keymanager import Keymanager
 from .multi_beacon_node import MultiBeaconNode
 from .remote_signer import RemoteSigner
+from .signature_provider import SignatureProvider
 
 __all__ = [
     "DB",
     "BeaconChain",
     "BeaconNode",
+    "Keymanager",
     "MultiBeaconNode",
     "RemoteSigner",
+    "SignatureProvider",
 ]

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -417,7 +417,7 @@ class BeaconNode:
     async def get_validators(
         self,
         ids: list[str],
-        statuses: list[SchemaBeaconAPI.ValidatorStatus],
+        statuses: list[SchemaBeaconAPI.ValidatorStatus] | None = None,
         state_id: str = "head",
     ) -> list[SchemaValidator.ValidatorIndexPubkey]:
         if len(ids) == 0:
@@ -430,7 +430,7 @@ class BeaconNode:
             data=self.json_encoder.encode(
                 {
                     "ids": ids,
-                    "statuses": [s.value for s in statuses],
+                    "statuses": [s.value for s in statuses] if statuses else None,
                 }
             ),
         )

--- a/src/providers/db/db.py
+++ b/src/providers/db/db.py
@@ -1,0 +1,74 @@
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from providers.db.migrations import MIGRATIONS, DbMigration
+
+
+class DB:
+    def __init__(
+        self,
+        data_dir: str,
+    ):
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.setLevel(logging.getLogger().level)
+
+        self.db_filepath = Path(data_dir) / "vero.db"
+        self.connection = sqlite3.connect(self.db_filepath, autocommit=False)
+
+    @property
+    def current_version(self) -> int:
+        try:
+            with self.connection:
+                version = self.connection.execute(
+                    "SELECT version FROM db_version;"
+                ).fetchone()[0]
+                return int(version)
+        except sqlite3.OperationalError as e:
+            if "no such table: db_version" in str(e):
+                # DB does not exist yet
+                return -1
+            raise
+
+    def run_migration_statements(self, migration: DbMigration) -> None:
+        self.logger.info(f"Migrating to version {migration.version}")
+
+        conn = self.connection
+
+        # sqlite3 with autocommit=False cannot change the WAL journal mode of the
+        # database because sqlite3 implicitly begins a transaction. The initial
+        # migration (version 0) has its autocommit attribute set to True to
+        # make it possible to run its journal mode-changing statement.
+        if migration.autocommit_mode:
+            conn = sqlite3.connect(self.db_filepath, autocommit=True)
+
+        with conn:
+            for stmt in migration.statements:
+                conn.executescript(stmt)
+            if migration.bump_version:
+                conn.execute("UPDATE db_version SET version = ?", (migration.version,))
+
+    def run_migrations(self) -> None:
+        if self.current_version == max(m.version for m in MIGRATIONS):
+            return
+
+        self.logger.info("Running database migrations")
+
+        for migration in sorted(MIGRATIONS, key=lambda m: m.version):
+            if self.current_version >= migration.version:
+                # Migration already applied
+                continue
+
+            self.run_migration_statements(migration)
+
+    def fetch_one(
+        self, sql: str, parameters: tuple[Any, ...] = ()
+    ) -> tuple[tuple[Any, ...] | None, int]:
+        with self.connection:
+            cursor = self.connection.execute(sql, parameters)
+            return cursor.fetchone(), cursor.rowcount
+
+    def fetch_all(self, sql: str, parameters: tuple[Any, ...] = ()) -> list[Any]:
+        with self.connection:
+            return self.connection.execute(sql, parameters).fetchall()

--- a/src/providers/db/db.py
+++ b/src/providers/db/db.py
@@ -53,8 +53,6 @@ class DB:
         if self.current_version == max(m.version for m in MIGRATIONS):
             return
 
-        self.logger.info("Running database migrations")
-
         for migration in sorted(MIGRATIONS, key=lambda m: m.version):
             if self.current_version >= migration.version:
                 # Migration already applied

--- a/src/providers/db/migrations.py
+++ b/src/providers/db/migrations.py
@@ -1,0 +1,33 @@
+import msgspec
+
+
+class DbMigration(msgspec.Struct):
+    version: int
+    description: str
+    statements: list[str]
+    # Automatically executes a UPDATE db_version statement
+    # after migrations are done
+    bump_version: bool
+    autocommit_mode: bool = False
+
+
+MIGRATIONS = [
+    DbMigration(
+        version=0,
+        description="Change into WAL mode",
+        statements=[
+            "PRAGMA journal_mode=WAL;",
+        ],
+        autocommit_mode=True,
+        bump_version=False,
+    ),
+    DbMigration(
+        version=1,
+        description="Create initial db_version table",
+        statements=[
+            "CREATE TABLE db_version (version INTEGER) STRICT;",
+            "INSERT INTO db_version VALUES (1);",
+        ],
+        bump_version=False,
+    ),
+]

--- a/src/providers/db/migrations.py
+++ b/src/providers/db/migrations.py
@@ -30,4 +30,20 @@ MIGRATIONS = [
         ],
         bump_version=False,
     ),
+    DbMigration(
+        version=2,
+        description="Create tables needed for the Keymanager API",
+        statements=[
+            """
+            CREATE TABLE keymanager_data (
+                pubkey TEXT PRIMARY KEY,
+                url TEXT NOT NULL,
+                fee_recipient TEXT,
+                gas_limit TEXT,
+                graffiti TEXT
+            ) STRICT;
+            """
+        ],
+        bump_version=True,
+    ),
 ]

--- a/src/providers/keymanager.py
+++ b/src/providers/keymanager.py
@@ -353,7 +353,7 @@ class Keymanager(SignatureProvider):
         msg, sig, pubkey = await self.sign(
             message=SchemaRemoteSigner.VoluntaryExitSignableMessage(
                 fork_info=self.beacon_chain.get_fork_info(
-                    slot=self.beacon_chain.spec.SLOTS_PER_EPOCH * epoch
+                    slot=self.beacon_chain.SLOTS_PER_EPOCH * epoch
                 ),
                 voluntary_exit=SchemaRemoteSigner.VoluntaryExit(
                     epoch=str(epoch), validator_index=str(validator_index)

--- a/src/providers/keymanager.py
+++ b/src/providers/keymanager.py
@@ -1,0 +1,426 @@
+import asyncio
+import contextlib
+import logging
+import sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor
+from sqlite3 import IntegrityError
+from types import TracebackType
+from typing import Self
+
+from args import CLIArgs
+from schemas import SchemaRemoteSigner
+from schemas.keymanager_api import (
+    DeleteStatus,
+    DeleteStatusMessage,
+    EthAddress,
+    ImportStatus,
+    ImportStatusMessage,
+    Pubkey,
+    RemoteKey,
+    SignedVoluntaryExit,
+    UInt64String,
+    ValidatorFeeRecipient,
+    ValidatorGasLimit,
+    ValidatorGraffiti,
+    VoluntaryExit,
+)
+
+from .beacon_chain import BeaconChain
+from .db.db import DB
+from .multi_beacon_node import MultiBeaconNode
+from .remote_signer import RemoteSigner
+from .signature_provider import SignatureProvider
+
+
+class PubkeyNotFound(Exception):
+    def __init__(self, pubkey: Pubkey):
+        self.pubkey = pubkey
+
+
+class Keymanager(SignatureProvider):
+    def __init__(
+        self,
+        db: DB,
+        beacon_chain: BeaconChain,
+        multi_beacon_node: MultiBeaconNode,
+        cli_args: CLIArgs,
+        process_pool_executor: ProcessPoolExecutor,
+    ):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.db = db
+        self.beacon_chain = beacon_chain
+        self.multi_beacon_node = multi_beacon_node
+
+        self.enabled = cli_args.enable_keymanager_api
+        self.pubkey_to_remote_signer: dict[str, RemoteSigner] = {}
+        self.pubkey_to_fee_recipient_override: dict[str, EthAddress] = {}
+        self.pubkey_to_gas_limit_override: dict[str, UInt64String] = {}
+        self.pubkey_to_graffiti_override: dict[str, str] = {}
+
+        self.process_pool_executor = process_pool_executor
+
+        # We'll create this in `Keymanager.__aenter__`
+        self._exit_stack: contextlib.AsyncExitStack | None = None
+
+        if self.enabled:
+            self.pubkey_to_fee_recipient_override = self._load_fee_recipient_override()
+            self.pubkey_to_gas_limit_override = self._load_gas_limit_override()
+            self.pubkey_to_graffiti_override = self._load_graffiti_override()
+
+            # Spin up API app
+            from api.keymanager import start_server
+
+            # do not actually start a server while running tests
+            if "pytest" in sys.modules:
+                return
+            self.api_task = asyncio.create_task(
+                start_server(keymanager=self, cli_args=cli_args)
+            )
+
+    async def __aenter__(self) -> Self:
+        # Create an AsyncExitStack for dynamically-managed signers
+        self._exit_stack = contextlib.AsyncExitStack()
+        # Enter the stack so it's ready
+        await self._exit_stack.__aenter__()
+
+        await self._update_pubkey_to_remote_signer_mapping()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if hasattr(self, "api_task"):
+            self.api_task.cancel()
+
+        # Let the stack close all signers in reverse order
+        if self._exit_stack is not None:
+            await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def _update_pubkey_to_remote_signer_mapping(self) -> None:
+        """
+        Update the pubkey-to-RemoteSigner mapping based on records in keymanager_data.
+        Any pubkey not in the DB is removed.
+
+        - If a pubkey already has a matching RemoteSigner (same URL), it is reused.
+        - If another pubkey's RemoteSigner (same URL) can be reused, do so.
+        - Otherwise, a new RemoteSigner is instantiated.
+        """
+        if self._exit_stack is None:
+            raise RuntimeError("Keymanager._exit_stack not set!")
+
+        # Fetch all (pubkey, url) pairs from the DB
+        rows = self.db.fetch_all("SELECT pubkey, url FROM keymanager_data;")
+
+        # Keep a quick-lookup dict from URL -> RemoteSigner so we can easily
+        # reuse any existing signers without scanning pubkey_to_remote_signer.
+        signers_by_url = {
+            signer.url: signer for signer in self.pubkey_to_remote_signer.values()
+        }
+
+        # Build a new mapping for pubkey -> RemoteSigner
+        new_mapping = {}
+
+        for pubkey, url in rows:
+            # If the pubkey already has a matching signer, just reuse it
+            existing_signer = self.pubkey_to_remote_signer.get(pubkey)
+            if existing_signer and existing_signer.url == url:
+                new_mapping[pubkey] = existing_signer
+                continue
+
+            # Otherwise, see if we can reuse a signer from signers_by_url
+            signer = signers_by_url.get(url)
+            if signer is not None:
+                new_mapping[pubkey] = signer
+                continue
+
+            # If we still don't have a signer, create a new one
+            signer = await self._exit_stack.enter_async_context(
+                RemoteSigner(url, process_pool_executor=self.process_pool_executor)
+            )
+            signers_by_url[url] = signer
+            new_mapping[pubkey] = signer
+
+        # Overwrite the old mapping with the new one
+        # This automatically drops any pubkey not present in the DB anymore
+        self.pubkey_to_remote_signer = new_mapping
+
+    def _load_fee_recipient_override(self) -> dict[str, str]:
+        return {
+            pk: fr
+            for pk, fr in self.db.fetch_all(
+                "SELECT pubkey, fee_recipient FROM keymanager_data;",
+            )
+            if fr is not None
+        }
+
+    def _load_gas_limit_override(self) -> dict[str, str]:
+        return {
+            pk: gl
+            for pk, gl in self.db.fetch_all(
+                "SELECT pubkey, gas_limit FROM keymanager_data;",
+            )
+            if gl is not None
+        }
+
+    def _load_graffiti_override(self) -> dict[str, str]:
+        return {
+            pk: graffiti
+            for pk, graffiti in self.db.fetch_all(
+                "SELECT pubkey, graffiti FROM keymanager_data;",
+            )
+            if graffiti is not None
+        }
+
+    def get_fee_recipient(self, pubkey: Pubkey) -> ValidatorFeeRecipient:
+        res, _ = self.db.fetch_one(
+            "SELECT fee_recipient FROM keymanager_data WHERE pubkey=?;", (pubkey,)
+        )
+        if res is None:
+            raise PubkeyNotFound(pubkey)
+
+        return ValidatorFeeRecipient(pubkey=pubkey, ethaddress=res[0])
+
+    def set_fee_recipient(self, pubkey: Pubkey, fee_recipient: EthAddress) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET fee_recipient=? WHERE pubkey=?;",
+            (fee_recipient, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        self.pubkey_to_fee_recipient_override[pubkey] = fee_recipient
+
+    def delete_configured_fee_recipient(self, pubkey: Pubkey) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET fee_recipient=? WHERE pubkey=?;",
+            (None, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        with contextlib.suppress(KeyError):
+            del self.pubkey_to_fee_recipient_override[pubkey]
+
+    def get_gas_limit(self, pubkey: Pubkey) -> ValidatorGasLimit:
+        res, _ = self.db.fetch_one(
+            "SELECT gas_limit FROM keymanager_data WHERE pubkey=?;", (pubkey,)
+        )
+        if res is None:
+            raise PubkeyNotFound(pubkey)
+
+        return ValidatorGasLimit(pubkey=pubkey, gas_limit=res[0])
+
+    def set_gas_limit(self, pubkey: Pubkey, gas_limit: UInt64String) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET gas_limit=? WHERE pubkey=?;",
+            (gas_limit, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        self.pubkey_to_gas_limit_override[pubkey] = gas_limit
+
+    def delete_configured_gas_limit(self, pubkey: Pubkey) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET gas_limit=? WHERE pubkey=?;",
+            (None, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        with contextlib.suppress(KeyError):
+            del self.pubkey_to_gas_limit_override[pubkey]
+
+    def get_graffiti(self, pubkey: Pubkey) -> ValidatorGraffiti:
+        res, _ = self.db.fetch_one(
+            "SELECT graffiti FROM keymanager_data WHERE pubkey=?;", (pubkey,)
+        )
+        if res is None:
+            raise PubkeyNotFound(pubkey)
+
+        return ValidatorGraffiti(pubkey=pubkey, graffiti=res[0])
+
+    def set_graffiti(self, pubkey: Pubkey, graffiti: str) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET graffiti=? WHERE pubkey=?;",
+            (graffiti, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        self.pubkey_to_graffiti_override[pubkey] = graffiti
+
+    def delete_configured_graffiti_value(self, pubkey: Pubkey) -> None:
+        _, rowcount = self.db.fetch_one(
+            "UPDATE keymanager_data SET graffiti=? WHERE pubkey=?;",
+            (None, pubkey),
+        )
+        if rowcount == 0:
+            raise PubkeyNotFound(pubkey)
+        with contextlib.suppress(KeyError):
+            del self.pubkey_to_graffiti_override[pubkey]
+
+    def list_remote_keys(self) -> list[RemoteKey]:
+        return [
+            RemoteKey(pk, signer.url)
+            for pk, signer in self.pubkey_to_remote_signer.items()
+        ]
+
+    async def import_remote_keys(
+        self, remote_keys: list[RemoteKey]
+    ) -> list[ImportStatusMessage]:
+        import_status_messages: list[ImportStatusMessage] = []
+
+        for remote_key in remote_keys:
+            try:
+                self.db.fetch_one(
+                    "INSERT INTO keymanager_data VALUES (?, ?, ?, ?, ?);",
+                    (remote_key.pubkey, remote_key.url, None, None, None),
+                )
+            except Exception as e:
+                if (
+                    isinstance(e, IntegrityError)
+                    and repr(e)
+                    == "IntegrityError('UNIQUE constraint failed: keymanager_data.pubkey')"
+                ):
+                    response_status = ImportStatus.DUPLICATE
+                    message = ""
+                else:
+                    response_status = ImportStatus.ERROR
+                    message = repr(e)
+            else:
+                response_status = ImportStatus.IMPORTED
+                message = ""
+            finally:
+                import_status_messages.append(
+                    ImportStatusMessage(
+                        status=response_status,
+                        message=message,
+                    )
+                )
+
+        await self._update_pubkey_to_remote_signer_mapping()
+
+        return import_status_messages
+
+    async def delete_remote_keys(
+        self, pubkeys: list[Pubkey]
+    ) -> list[DeleteStatusMessage]:
+        delete_status_messages: list[DeleteStatusMessage] = []
+
+        for pubkey in pubkeys:
+            try:
+                _, rowcount = self.db.fetch_one(
+                    "DELETE FROM keymanager_data WHERE pubkey=?;", (pubkey,)
+                )
+            except Exception as e:
+                response_status = DeleteStatus.ERROR
+                message = repr(e)
+            else:
+                if rowcount == 0:
+                    response_status = DeleteStatus.NOT_FOUND
+                else:
+                    response_status = DeleteStatus.DELETED
+                message = ""
+            finally:
+                delete_status_messages.append(
+                    DeleteStatusMessage(
+                        status=response_status,
+                        message=message,
+                    )
+                )
+
+        await self._update_pubkey_to_remote_signer_mapping()
+
+        return delete_status_messages
+
+    async def sign_voluntary_exit_message(
+        self, pubkey: Pubkey, epoch: int | None
+    ) -> SignedVoluntaryExit:
+        # Determine if validator is active and its validator index
+        val_idx_pubkeys = await self.multi_beacon_node.get_validators(
+            ids=[pubkey],
+        )
+        if len(val_idx_pubkeys) == 0:
+            raise ValueError(f"Failed to find validator index for pubkey: {pubkey}")
+
+        validator_index = next(iter(val_idx_pubkeys)).index
+
+        # Per Keymanager API spec - if no epoch is provided, use the current one
+        if epoch is None:
+            epoch = self.beacon_chain.current_epoch
+
+        msg, sig, pubkey = await self.sign(
+            message=SchemaRemoteSigner.VoluntaryExitSignableMessage(
+                fork_info=self.beacon_chain.get_fork_info(
+                    slot=self.beacon_chain.spec.SLOTS_PER_EPOCH * epoch
+                ),
+                voluntary_exit=SchemaRemoteSigner.VoluntaryExit(
+                    epoch=str(epoch), validator_index=str(validator_index)
+                ),
+            ),
+            identifier=pubkey,
+        )
+        return SignedVoluntaryExit(
+            message=VoluntaryExit(
+                epoch=str(epoch),
+                validator_index=str(validator_index),
+            ),
+            signature=sig,
+        )
+
+    async def sign(
+        self,
+        message: SchemaRemoteSigner.SignableMessageT,
+        identifier: str,
+    ) -> tuple[SchemaRemoteSigner.SignableMessageT, str, str]:
+        signer = self.pubkey_to_remote_signer.get(identifier)
+
+        if signer is None:
+            # This can happen when a key is deleted but a duty had already been
+            # scheduled for it. A signature for something will be requested,
+            # Keymanager will raise in this case.
+            raise PubkeyNotFound(identifier)
+
+        return await signer.sign(
+            message=message,
+            identifier=identifier,
+        )
+
+    async def sign_in_batches(
+        self,
+        messages: list[SchemaRemoteSigner.SignableMessageT],
+        identifiers: list[str],
+        batch_size: int = 100,
+    ) -> list[tuple[SchemaRemoteSigner.SignableMessageT, str, str]]:
+        signer_inputs: defaultdict[
+            RemoteSigner, tuple[list[SchemaRemoteSigner.SignableMessageT], list[str]]
+        ] = defaultdict(lambda: ([], []))
+
+        for message, identifier in zip(messages, identifiers, strict=False):
+            signer = self.pubkey_to_remote_signer.get(identifier)
+            if signer is None:
+                # This can happen when a key is deleted but a duty had already been
+                # scheduled for it. A signature for something will be requested,
+                # Keymanager will log a warning here and NOT sign the message.
+                self.logger.warning(
+                    f"No signer found for {identifier} - not signing message"
+                )
+                continue
+
+            signer_inputs[signer][0].append(message)
+            signer_inputs[signer][1].append(identifier)
+
+        tasks = [
+            signer.sign_in_batches(messages, identifiers, batch_size)
+            for signer, (messages, identifiers) in signer_inputs.items()
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Flatten the list of results
+        return [item for sublist in results for item in sublist]
+
+    async def get_public_keys(self) -> list[Pubkey]:
+        return [
+            row for (row,) in self.db.fetch_all("SELECT pubkey FROM keymanager_data;")
+        ]

--- a/src/providers/signature_provider.py
+++ b/src/providers/signature_provider.py
@@ -1,0 +1,21 @@
+from schemas import SchemaRemoteSigner
+
+
+class SignatureProvider:
+    async def sign(
+        self,
+        message: SchemaRemoteSigner.SignableMessageT,
+        identifier: str,
+    ) -> tuple[SchemaRemoteSigner.SignableMessageT, str, str]:
+        raise NotImplementedError
+
+    async def sign_in_batches(
+        self,
+        messages: list[SchemaRemoteSigner.SignableMessageT],
+        identifiers: list[str],
+        batch_size: int = 100,
+    ) -> list[tuple[SchemaRemoteSigner.SignableMessageT, str, str]]:
+        raise NotImplementedError
+
+    async def get_public_keys(self) -> list[str]:
+        raise NotImplementedError

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,9 +1,11 @@
 import schemas.beacon_api as SchemaBeaconAPI
+import schemas.keymanager_api as SchemaKeymanagerAPI
 import schemas.remote_signer as SchemaRemoteSigner
 import schemas.validator as SchemaValidator
 
 __all__ = [
     "SchemaBeaconAPI",
+    "SchemaKeymanagerAPI",
     "SchemaRemoteSigner",
     "SchemaValidator",
 ]

--- a/src/schemas/keymanager_api.py
+++ b/src/schemas/keymanager_api.py
@@ -1,0 +1,120 @@
+from enum import Enum
+from typing import Annotated
+
+import msgspec
+
+Pubkey = Annotated[str, msgspec.Meta(pattern="^0x[a-fA-F0-9]{96}$")]
+EthAddress = Annotated[str, msgspec.Meta(pattern="^0x[a-fA-F0-9]{40}$")]
+UInt64String = Annotated[str, msgspec.Meta(pattern="^(0|[1-9][0-9]{0,19})$")]
+BLSSignature = Annotated[str, msgspec.Meta(pattern="^0x[a-fA-F0-9]{192}$")]
+
+
+class ErrorResponse(msgspec.Struct):
+    message: str
+
+
+class RemoteKey(msgspec.Struct):
+    pubkey: Pubkey
+    url: str
+
+
+class RemoteKeyWithReadOnlyStatus(RemoteKey):
+    readonly: bool
+
+
+class ListRemoteKeysResponse(msgspec.Struct):
+    data: list[RemoteKeyWithReadOnlyStatus]
+
+
+class ImportRemoteKeysRequest(msgspec.Struct):
+    remote_keys: list[RemoteKey]
+
+
+class ImportStatus(Enum):
+    IMPORTED = "imported"
+    DUPLICATE = "duplicate"
+    ERROR = "error"
+
+
+class ImportStatusMessage(msgspec.Struct):
+    status: ImportStatus
+    message: str
+
+
+class ImportRemoteKeysResponse(msgspec.Struct):
+    data: list[ImportStatusMessage]
+
+
+class DeleteRemoteKeysRequest(msgspec.Struct):
+    pubkeys: list[Pubkey]
+
+
+class DeleteStatus(Enum):
+    DELETED = "deleted"
+    NOT_FOUND = "not_found"
+    ERROR = "error"
+
+
+class DeleteStatusMessage(msgspec.Struct):
+    status: DeleteStatus
+    message: str
+
+
+class DeleteRemoteKeysResponse(msgspec.Struct):
+    data: list[DeleteStatusMessage]
+
+
+# Fee recipient endpoints
+class ValidatorFeeRecipient(msgspec.Struct):
+    pubkey: Pubkey
+    ethaddress: EthAddress | None
+
+
+class ListFeeRecipientResponse(msgspec.Struct):
+    data: ValidatorFeeRecipient
+
+
+class SetFeeRecipientRequest(msgspec.Struct):
+    ethaddress: EthAddress
+
+
+# Gas limit endpoints
+class ValidatorGasLimit(msgspec.Struct):
+    pubkey: Pubkey
+    gas_limit: UInt64String | None
+
+
+class ListGasLimitResponse(msgspec.Struct):
+    data: ValidatorGasLimit
+
+
+class SetGasLimitRequest(msgspec.Struct):
+    gas_limit: UInt64String
+
+
+# Graffiti endpoints
+class ValidatorGraffiti(msgspec.Struct):
+    pubkey: Pubkey
+    graffiti: str | None
+
+
+class GraffitiResponse(msgspec.Struct):
+    data: ValidatorGraffiti
+
+
+class SetGraffitiRequest(msgspec.Struct):
+    graffiti: str
+
+
+class VoluntaryExit(msgspec.Struct):
+    epoch: UInt64String
+    validator_index: UInt64String
+
+
+class SignedVoluntaryExit(msgspec.Struct):
+    message: VoluntaryExit
+    signature: BLSSignature
+
+
+class SignVoluntaryExitResponse(msgspec.Struct):
+    data: SignedVoluntaryExit

--- a/src/schemas/remote_signer.py
+++ b/src/schemas/remote_signer.py
@@ -15,6 +15,7 @@ class SigningRequestType(Enum):
     SYNC_COMMITTEE_MESSAGE = "SYNC_COMMITTEE_MESSAGE"
     SYNC_COMMITTEE_SELECTION_PROOF = "SYNC_COMMITTEE_SELECTION_PROOF"
     VALIDATOR_REGISTRATION = "VALIDATOR_REGISTRATION"
+    VOLUNTARY_EXIT = "VOLUNTARY_EXIT"
 
 
 SignableMessageT = TypeVar("SignableMessageT", bound="SignableMessage")
@@ -134,3 +135,13 @@ class ValidatorRegistration(msgspec.Struct):
 class ValidatorRegistrationSignableMessage(SignableMessage, kw_only=True):
     type: SigningRequestType = SigningRequestType.VALIDATOR_REGISTRATION
     validator_registration: ValidatorRegistration
+
+
+class VoluntaryExit(msgspec.Struct):
+    epoch: str
+    validator_index: str
+
+
+class VoluntaryExitSignableMessage(SignableMessageWithForkInfo, kw_only=True):
+    type: SigningRequestType = SigningRequestType.VOLUNTARY_EXIT
+    voluntary_exit: VoluntaryExit

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -262,7 +262,7 @@ class AttestationService(ValidatorDutyService):
 
                 for coro in asyncio.as_completed(
                     [
-                        self.remote_signer.sign(
+                        self.signature_provider.sign(
                             message=SchemaRemoteSigner.AttestationSignableMessage(
                                 fork_info=_fork_info,
                                 attestation=att_data_obj
@@ -415,7 +415,7 @@ class AttestationService(ValidatorDutyService):
         fork_version: SchemaBeaconAPI.ForkVersion,
     ) -> None:
         signed_aggregate_and_proofs = []
-        for msg, sig, _identifier in await self.remote_signer.sign_in_batches(  # type: ignore[misc]
+        for msg, sig, _identifier in await self.signature_provider.sign_in_batches(  # type: ignore[misc]
             messages=messages,
             identifiers=identifiers,
         ):
@@ -551,7 +551,7 @@ class AttestationService(ValidatorDutyService):
                 )
                 identifiers.append(duty.pubkey)
 
-            signatures = await self.remote_signer.sign_in_batches(
+            signatures = await self.signature_provider.sign_in_batches(
                 messages=signable_messages,
                 identifiers=identifiers,
             )

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -347,9 +347,9 @@ class BlockProposalService(ValidatorDutyService):
             ):
                 graffiti = self.cli_args.graffiti
                 if self.keymanager.enabled:
-                    kmgr_graffiti_str = self.keymanager.get_graffiti(
-                        duty.pubkey
-                    ).graffiti
+                    kmgr_graffiti_str = self.keymanager.pubkey_to_graffiti_override.get(
+                        duty.pubkey, None
+                    )
                     if kmgr_graffiti_str is not None:
                         self.logger.info(
                             f"Using Keymanager-provided graffiti: {kmgr_graffiti_str}"

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -158,7 +158,7 @@ class SyncCommitteeService(ValidatorDutyService):
 
         _fork_info = self.beacon_chain.get_fork_info(slot=duty_slot)
         coroutines = [
-            self.remote_signer.sign(
+            self.signature_provider.sign(
                 message=SchemaRemoteSigner.SyncCommitteeMessageSignableMessage(
                     fork_info=_fork_info,
                     sync_committee_message=SchemaRemoteSigner.SyncCommitteeMessage(
@@ -251,7 +251,7 @@ class SyncCommitteeService(ValidatorDutyService):
             )
             selection_proofs_coroutines.extend(
                 [
-                    self.remote_signer.sign(
+                    self.signature_provider.sign(
                         SchemaRemoteSigner.SyncCommitteeSelectionProofSignableMessage(
                             fork_info=_fork_info,
                             sync_aggregator_selection_data=SchemaRemoteSigner.SyncAggregatorSelectionData(
@@ -328,7 +328,7 @@ class SyncCommitteeService(ValidatorDutyService):
         identifiers: list[str],
     ) -> None:
         signed_contribution_and_proofs = []
-        for msg, sig, _identifier in await self.remote_signer.sign_in_batches(
+        for msg, sig, _identifier in await self.signature_provider.sign_in_batches(
             messages=messages,
             identifiers=identifiers,
         ):

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -9,7 +9,7 @@ from prometheus_client import Histogram
 
 from args import CLIArgs
 from observability import ErrorType, get_shared_metrics
-from providers import BeaconChain, MultiBeaconNode, RemoteSigner
+from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvider
 from schemas import SchemaBeaconAPI
 from tasks import TaskManager
 
@@ -30,7 +30,8 @@ class ValidatorDuty(Enum):
 class ValidatorDutyServiceOptions(TypedDict):
     multi_beacon_node: MultiBeaconNode
     beacon_chain: BeaconChain
-    remote_signer: RemoteSigner
+    signature_provider: SignatureProvider
+    keymanager: Keymanager
     validator_status_tracker_service: "ValidatorStatusTrackerService"
     scheduler: AsyncIOScheduler
     task_manager: TaskManager
@@ -65,7 +66,8 @@ class ValidatorDutyService:
     ):
         self.multi_beacon_node = kwargs["multi_beacon_node"]
         self.beacon_chain = kwargs["beacon_chain"]
-        self.remote_signer = kwargs["remote_signer"]
+        self.signature_provider = kwargs["signature_provider"]
+        self.keymanager = kwargs["keymanager"]
         self.validator_status_tracker_service = kwargs[
             "validator_status_tracker_service"
         ]

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -21,12 +21,14 @@ async def shut_down(
     # Wait until there are no upcoming block proposal duties
     while block_proposal_service.has_upcoming_duty():
         duty_slot = block_proposal_service.next_duty_slot
+        if duty_slot is None:
+            break
 
         _logger.info(
             f"Waiting for upcoming block proposal to complete during slot {duty_slot}"
         )
 
-        while duty_slot != beacon_chain.current_slot:
+        while beacon_chain.current_slot < duty_slot:
             _logger.info(f"Waiting for block proposal duty slot ({duty_slot}) to start")
             await beacon_chain.wait_for_next_slot()
 

--- a/src/spec/utils.py
+++ b/src/spec/utils.py
@@ -1,0 +1,10 @@
+def encode_graffiti(graffiti_string: str) -> bytes:
+    _graffiti_max_bytes = 32
+
+    encoded = graffiti_string.encode("utf-8").ljust(_graffiti_max_bytes, b"\x00")
+    if len(encoded) > _graffiti_max_bytes:
+        raise ValueError(
+            f"Encoded graffiti exceeds the maximum length of {_graffiti_max_bytes} bytes"
+        )
+
+    return encoded

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -68,3 +68,7 @@ class TaskManager:
         task: asyncio.Task[None] = asyncio.create_task(_delayed_coro(), name=name)
         task.add_done_callback(partial(self.task_done_callback))
         self._tasks.add(task)
+
+    def cancel_all(self) -> None:
+        for task in self._tasks:
+            task.cancel()

--- a/tests/api/keymanager/conftest.py
+++ b/tests/api/keymanager/conftest.py
@@ -1,0 +1,22 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from api.keymanager.api import _create_app
+from args import CLIArgs
+from providers import Keymanager
+
+
+@pytest.fixture
+async def test_client(
+    aiohttp_client: Callable[..., Awaitable[TestClient[Any, Application]]],
+    keymanager: Keymanager,
+    cli_args: CLIArgs,
+) -> TestClient[Any, Application]:
+    app = _create_app(keymanager=keymanager, cli_args=cli_args)
+    return await aiohttp_client(
+        app, headers={"Authorization": f"Bearer {app['bearer_token']}"}
+    )

--- a/tests/api/keymanager/test_api.py
+++ b/tests/api/keymanager/test_api.py
@@ -1,0 +1,71 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import msgspec
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from api.keymanager.api import _create_app
+from args import CLIArgs
+from providers import Keymanager
+from schemas import SchemaKeymanagerAPI
+
+
+async def test_bearer_auth(
+    aiohttp_client: Callable[[Application], Awaitable[TestClient[Any, Application]]],
+    keymanager: Keymanager,
+    cli_args: CLIArgs,
+) -> None:
+    app = _create_app(keymanager=keymanager, cli_args=cli_args)
+    test_client = await aiohttp_client(app)
+
+    # Make a request without a value for the Authorization header
+    resp = await test_client.get(
+        "/eth/v1/remotekeys",
+    )
+    assert resp.status == 401
+
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ErrorResponse
+    )
+    assert response.message == "No value provided for Authorization header"
+
+    # Make a request with a wrong value for the Authorization header
+    resp = await test_client.get(
+        "/eth/v1/remotekeys", headers={"Authorization": "Bearer wrong-value"}
+    )
+    assert resp.status == 403
+
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ErrorResponse
+    )
+    assert response.message == "Invalid value provided for Authorization header"
+
+    # Make a request with the correct value for the Authorization header
+    resp = await test_client.get(
+        "/eth/v1/remotekeys",
+        headers={"Authorization": f"Bearer {test_client.app['bearer_token']}"},
+    )
+    assert resp.status == 200
+
+
+async def test_bad_request(
+    test_client: TestClient[Any, Application],
+    keymanager: Keymanager,
+    cli_args: CLIArgs,
+) -> None:
+    # Submitting data that does not conform to the spec
+    # causes a 400 status code to be returned along with
+    # an explanatory message in JSON format.
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        json=dict(remote_keys=[dict(pubkey="0xinvalid", url="http://...")]),
+    )
+    assert resp.status == 400
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ErrorResponse
+    )
+    assert (
+        response.message
+        == "ValidationError(\"Expected `str` matching regex '^0x[a-fA-F0-9]{96}$' - at `$.remote_keys[0].pubkey`\")"
+    )

--- a/tests/api/keymanager/test_fee_recipient_endpoints.py
+++ b/tests/api/keymanager/test_fee_recipient_endpoints.py
@@ -1,0 +1,117 @@
+from typing import Any
+
+import msgspec.json
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from providers import Keymanager
+from schemas import SchemaKeymanagerAPI
+
+
+async def test_fee_recipient_lifecycle(
+    keymanager: Keymanager,
+    test_client: TestClient[Any, Application],
+) -> None:
+    # Import a key
+    pubkey = "0x" + "a" * 96
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url="http://whatever"),
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Its fee recipient should not be set yet
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/feerecipient")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListFeeRecipientResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.ethaddress is None
+    assert keymanager.pubkey_to_fee_recipient_override.get(pubkey) is None
+
+    # Set its fee recipient
+    fee_recipient_address = "0x" + "a" * 40
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/feerecipient",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetFeeRecipientRequest(
+                ethaddress=fee_recipient_address,
+            )
+        ),
+    )
+    assert resp.status == 202
+
+    # Its fee recipient should be set now
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/feerecipient")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListFeeRecipientResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.ethaddress == fee_recipient_address
+    assert (
+        keymanager.pubkey_to_fee_recipient_override.get(pubkey) == fee_recipient_address
+    )
+
+    # Delete its configured fee recipient
+    resp = await test_client.delete(f"/eth/v1/validator/{pubkey}/feerecipient")
+    assert resp.status == 204
+
+    # Its fee recipient should be unset again
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/feerecipient")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListFeeRecipientResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.ethaddress is None
+    assert keymanager.pubkey_to_fee_recipient_override.get(pubkey) is None
+
+
+async def test_nonexistent_pubkey(test_client: TestClient[Any, Application]) -> None:
+    nonexistent_pubkey = "0x" + "a" * 96
+
+    # Get its fee recipient
+    resp = await test_client.get(f"/eth/v1/validator/{nonexistent_pubkey}/feerecipient")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Set its fee recipient
+    fee_recipient_address = "0x" + "a" * 40
+    resp = await test_client.post(
+        f"/eth/v1/validator/{nonexistent_pubkey}/feerecipient",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetFeeRecipientRequest(
+                ethaddress=fee_recipient_address,
+            )
+        ),
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Delete its fee recipient
+    resp = await test_client.delete(
+        f"/eth/v1/validator/{nonexistent_pubkey}/feerecipient"
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+
+async def test_bad_request(test_client: TestClient[Any, Application]) -> None:
+    invalid_pubkey = "0x" + "x" * 96
+
+    # Get its fee recipient
+    resp = await test_client.get(f"/eth/v1/validator/{invalid_pubkey}/feerecipient")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{invalid_pubkey}')"

--- a/tests/api/keymanager/test_gas_limit_endpoints.py
+++ b/tests/api/keymanager/test_gas_limit_endpoints.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+import msgspec.json
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from providers import Keymanager
+from schemas import SchemaKeymanagerAPI
+
+
+async def test_gas_limit_lifecycle(
+    keymanager: Keymanager, test_client: TestClient[Any, Application]
+) -> None:
+    # Import a key
+    pubkey = "0x" + "a" * 96
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url="http://whatever"),
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Its gas limit value should not be set yet
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/gas_limit")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListGasLimitResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.gas_limit is None
+    assert keymanager.pubkey_to_gas_limit_override.get(pubkey) is None
+
+    # Set its gas limit value
+    gas_limit_value = "20000000"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/gas_limit",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGasLimitRequest(
+                gas_limit=gas_limit_value,
+            )
+        ),
+    )
+    assert resp.status == 202
+
+    # Its gas limit value should be set now
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/gas_limit")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListGasLimitResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.gas_limit == gas_limit_value
+    assert keymanager.pubkey_to_gas_limit_override.get(pubkey) == gas_limit_value
+
+    # Delete its configured gas limit value
+    resp = await test_client.delete(f"/eth/v1/validator/{pubkey}/gas_limit")
+    assert resp.status == 204
+
+    # Its gas limit value should be unset again
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/gas_limit")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListGasLimitResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.gas_limit is None
+    assert keymanager.pubkey_to_gas_limit_override.get(pubkey) is None
+
+
+async def test_nonexistent_pubkey(test_client: TestClient[Any, Application]) -> None:
+    nonexistent_pubkey = "0x" + "a" * 96
+
+    # Get its gas limit value
+    resp = await test_client.get(f"/eth/v1/validator/{nonexistent_pubkey}/gas_limit")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Set its gas limit value
+    gas_limit_value = "20000000"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{nonexistent_pubkey}/gas_limit",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGasLimitRequest(
+                gas_limit=gas_limit_value,
+            )
+        ),
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Delete its gas limit value
+    resp = await test_client.delete(f"/eth/v1/validator/{nonexistent_pubkey}/gas_limit")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"

--- a/tests/api/keymanager/test_graffiti_endpoints.py
+++ b/tests/api/keymanager/test_graffiti_endpoints.py
@@ -1,0 +1,167 @@
+from typing import Any
+
+import msgspec.json
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from providers import Keymanager
+from schemas import SchemaKeymanagerAPI
+
+
+async def test_graffiti_lifecycle(
+    keymanager: Keymanager, test_client: TestClient[Any, Application]
+) -> None:
+    # Import a key
+    pubkey = "0x" + "a" * 96
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url="http://whatever"),
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Its graffiti should not be set yet
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/graffiti")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.graffiti is None
+    assert keymanager.pubkey_to_graffiti_override.get(pubkey) is None
+
+    # Set its graffiti
+    graffiti_value = "Vero rocks"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/graffiti",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGraffitiRequest(
+                graffiti=graffiti_value,
+            )
+        ),
+    )
+    assert resp.status == 202
+
+    # Its graffiti should be set now
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/graffiti")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.graffiti == graffiti_value
+    assert keymanager.pubkey_to_graffiti_override.get(pubkey) == graffiti_value
+
+    # Delete its configured graffiti
+    resp = await test_client.delete(f"/eth/v1/validator/{pubkey}/graffiti")
+    assert resp.status == 204
+
+    # Its graffiti should be unset again
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/graffiti")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
+    )
+    assert response.data.pubkey == pubkey
+    assert response.data.graffiti is None
+    assert keymanager.pubkey_to_graffiti_override.get(pubkey) is None
+
+
+async def test_nonexistent_pubkey(test_client: TestClient[Any, Application]) -> None:
+    nonexistent_pubkey = "0x" + "a" * 96
+
+    # Get its graffiti
+    resp = await test_client.get(f"/eth/v1/validator/{nonexistent_pubkey}/graffiti")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Set its graffiti
+    graffiti = "Vero rocks"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{nonexistent_pubkey}/graffiti",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGraffitiRequest(graffiti=graffiti)
+        ),
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+    # Delete its graffiti
+    resp = await test_client.delete(f"/eth/v1/validator/{nonexistent_pubkey}/graffiti")
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{nonexistent_pubkey}')"
+
+
+async def test_set_emoji(test_client: TestClient[Any, Application]) -> None:
+    # Import a key
+    pubkey = "0x" + "a" * 96
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url="http://whatever"),
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Set its graffiti
+    graffiti_value = "🔥 Vero 🔥"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/graffiti",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGraffitiRequest(graffiti=graffiti_value)
+        ),
+    )
+    assert resp.status == 202
+
+    # Its graffiti should be set now
+    resp = await test_client.get(f"/eth/v1/validator/{pubkey}/graffiti")
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
+    )
+    assert response.data.graffiti == graffiti_value
+
+
+async def test_set_graffiti_too_long(
+    keymanager: Keymanager, test_client: TestClient[Any, Application]
+) -> None:
+    # Import a key
+    pubkey = "0x" + "a" * 96
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url="http://whatever"),
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Set its graffiti
+    graffiti_value = "🔥🔥🔥🔥🔥🔥 Vero 🔥🔥🔥🔥🔥🔥"
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/graffiti",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.SetGraffitiRequest(graffiti=graffiti_value)
+        ),
+    )
+    assert resp.status == 500
+    response = msgspec.json.decode(await resp.text())
+    assert (
+        "Encoded graffiti exceeds the maximum length of 32 bytes" in response["message"]
+    )
+    assert keymanager.pubkey_to_graffiti_override.get(pubkey) is None

--- a/tests/api/keymanager/test_remote_key_manager_endpoints.py
+++ b/tests/api/keymanager/test_remote_key_manager_endpoints.py
@@ -1,0 +1,113 @@
+import random
+from typing import Any
+
+import msgspec.json
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from schemas import SchemaKeymanagerAPI
+
+
+async def test_remote_keymanager_lifecycle(
+    test_client: TestClient[Any, Application],
+) -> None:
+    # List the keys - there should be 0 at this point
+    resp = await test_client.get("/eth/v1/remotekeys")
+    assert resp.status == 200
+    response_list_1 = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListRemoteKeysResponse
+    )
+    assert len(response_list_1.data) == 0
+
+    # Import some keys
+    keys_to_add = [
+        SchemaKeymanagerAPI.RemoteKey(pubkey="0x" + "a" * 96, url="http://whatever"),
+        SchemaKeymanagerAPI.RemoteKey(pubkey="0x" + "b" * 96, url="http://whatever"),
+    ]
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(remote_keys=keys_to_add)
+        ),
+    )
+    assert resp.status == 200
+    response_import = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ImportRemoteKeysResponse
+    )
+    assert len(response_import.data) == 2
+    assert all(
+        d.status == SchemaKeymanagerAPI.ImportStatus.IMPORTED
+        for d in response_import.data
+    )
+
+    # List the keys again - the keys should now show up
+    resp = await test_client.get("/eth/v1/remotekeys")
+    assert resp.status == 200
+    response_list_2 = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListRemoteKeysResponse
+    )
+    assert len(response_list_2.data) == 2
+
+    # Try to import the same keys again
+    # -> their import status should be reported as DUPLICATE
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(remote_keys=keys_to_add)
+        ),
+    )
+    assert resp.status == 200
+    response_import_2 = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ImportRemoteKeysResponse
+    )
+    assert all(
+        d.status == SchemaKeymanagerAPI.ImportStatus.DUPLICATE
+        for d in response_import_2.data
+    )
+
+    # Delete one of the keys
+    key_to_delete: SchemaKeymanagerAPI.RemoteKey = random.choice(keys_to_add)
+    resp = await test_client.delete(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.DeleteRemoteKeysRequest(pubkeys=[key_to_delete.pubkey])
+        ),
+    )
+    assert resp.status == 200
+    response_delete = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.DeleteRemoteKeysResponse
+    )
+    assert len(response_delete.data) == 1
+    assert all(
+        d.status == SchemaKeymanagerAPI.DeleteStatus.DELETED
+        for d in response_delete.data
+    )
+
+    # List the keys again. Only one key should remain now - the one we did not delete
+    resp = await test_client.get("/eth/v1/remotekeys")
+    assert resp.status == 200
+    response_list_3 = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.ListRemoteKeysResponse
+    )
+    assert len(response_list_3.data) == 1
+    assert response_list_3.data[0].pubkey != key_to_delete.pubkey
+
+
+async def test_nonexistent_pubkey(test_client: TestClient[Any, Application]) -> None:
+    nonexistent_pubkey = "0x" + "a" * 96
+
+    # Attempt to delete it
+    resp = await test_client.delete(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.DeleteRemoteKeysRequest(pubkeys=[nonexistent_pubkey])
+        ),
+    )
+    assert resp.status == 200
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.DeleteRemoteKeysResponse
+    )
+    assert len(response.data) == 1
+    assert all(
+        d.status == SchemaKeymanagerAPI.DeleteStatus.NOT_FOUND for d in response.data
+    )

--- a/tests/api/keymanager/test_voluntary_exit_endpoints.py
+++ b/tests/api/keymanager/test_voluntary_exit_endpoints.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import msgspec.json
+import pytest
+from aiohttp.test_utils import TestClient
+from aiohttp.web_app import Application
+
+from schemas import SchemaKeymanagerAPI
+from schemas.validator import ValidatorIndexPubkey
+
+
+@pytest.mark.parametrize(
+    argnames=("exit_epoch"),
+    argvalues=[
+        pytest.param(
+            None,
+            id="Not provided -> defaults to current epoch",
+        ),
+        pytest.param(
+            0,
+            id="Genesis - epoch 0",
+        ),
+        pytest.param(
+            1_000,
+            id="Future - epoch 1,000",
+        ),
+    ],
+)
+async def test_voluntary_exit_lifecycle(
+    exit_epoch: int | None,
+    random_active_validator: ValidatorIndexPubkey,
+    test_client: TestClient[Any, Application],
+    remote_signer_url: str,
+) -> None:
+    # Import a key
+    pubkey = random_active_validator.pubkey
+
+    resp = await test_client.post(
+        "/eth/v1/remotekeys",
+        data=msgspec.json.encode(
+            SchemaKeymanagerAPI.ImportRemoteKeysRequest(
+                remote_keys=[
+                    SchemaKeymanagerAPI.RemoteKey(pubkey=pubkey, url=remote_signer_url)
+                ]
+            )
+        ),
+    )
+    assert resp.status == 200
+
+    # Get its voluntary exit message
+    params = {}
+    if exit_epoch is not None:
+        params.update(dict(epoch=exit_epoch))
+
+    resp = await test_client.post(
+        f"/eth/v1/validator/{pubkey}/voluntary_exit", params=params
+    )
+    assert resp.status == 200
+    # Decoding the message is successful
+    response = msgspec.json.decode(
+        await resp.text(), type=SchemaKeymanagerAPI.SignVoluntaryExitResponse
+    )
+    if exit_epoch is not None:
+        assert int(response.data.message.epoch) == exit_epoch
+
+
+async def test_pubkey_inactive(test_client: TestClient[Any, Application]) -> None:
+    """
+    Validator pubkey that is not active on the beacon chain.
+    """
+    nonexistent_pubkey = "0x" + "a" * 96
+
+    # Attempt to get its voluntary exit message
+    resp = await test_client.post(
+        f"/eth/v1/validator/{nonexistent_pubkey}/voluntary_exit"
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert (
+        data["message"]
+        == f"ValueError('Failed to find validator index for pubkey: {nonexistent_pubkey}')"
+    )
+
+
+async def test_pubkey_not_registered(
+    random_active_validator: ValidatorIndexPubkey,
+    test_client: TestClient[Any, Application],
+) -> None:
+    """
+    Validator pubkey that was never registered with the Keymanager API
+    """
+    # Attempt to get its voluntary exit message
+    resp = await test_client.post(
+        f"/eth/v1/validator/{random_active_validator.pubkey}/voluntary_exit"
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["message"] == f"PubkeyNotFound('{random_active_validator.pubkey}')"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import random
 import time
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncGenerator, Generator
-from tempfile import TemporaryDirectory
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
 from unittest import mock
 
 import milagro_bls_binding as bls
@@ -12,8 +13,15 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs, _process_attestation_consensus_threshold
 from observability import init_observability
-from providers import BeaconChain, MultiBeaconNode, RemoteSigner
-from schemas import SchemaBeaconAPI
+from providers import (
+    BeaconChain,
+    MultiBeaconNode,
+    RemoteSigner,
+    Keymanager,
+    DB,
+    SignatureProvider,
+)
+from schemas import SchemaBeaconAPI, SchemaKeymanagerAPI
 from schemas.beacon_api import ForkVersion
 from schemas.validator import ACTIVE_STATUSES, ValidatorIndexPubkey
 from services import ValidatorStatusTrackerService
@@ -38,29 +46,39 @@ def beacon_node_urls_proposal(request: pytest.FixtureRequest) -> list[str]:
     return getattr(request, "param", [])
 
 
+@pytest.fixture
+def enable_keymanager_api(request: pytest.FixtureRequest) -> bool:
+    # Default to false if not otherwise requested through indirect parametrization
+    return getattr(request, "param", False)
+
+
 @pytest.fixture(scope="session")
 def cli_args(
     remote_signer_url: str,
     beacon_node_url: str,
     beacon_node_urls_proposal: list[str],
+    enable_keymanager_api: bool,
+    tmp_path: Path,
 ) -> CLIArgs:
-    tmp_dir = TemporaryDirectory()
-
     return CLIArgs(
         network=Network._TESTS,
         network_custom_config_path=None,
-        remote_signer_url=remote_signer_url,
+        remote_signer_url=None if enable_keymanager_api else remote_signer_url,
         beacon_node_urls=[beacon_node_url],
         beacon_node_urls_proposal=beacon_node_urls_proposal,
         attestation_consensus_threshold=_process_attestation_consensus_threshold(
             None, [beacon_node_url]
         ),
         fee_recipient="0x0000000000000000000000000000000000000000",
-        data_dir=tmp_dir.name,
-        use_external_builder=False,
-        builder_boost_factor=90,
+        data_dir=str(tmp_path),
         graffiti=b"pytest",
         gas_limit=30_000_000,
+        use_external_builder=False,
+        builder_boost_factor=90,
+        enable_keymanager_api=enable_keymanager_api,
+        keymanager_api_token_file_path=tmp_path / "keymanager-api-token.txt",
+        keymanager_api_address="localhost",
+        keymanager_api_port=8001,
         metrics_address="localhost",
         metrics_port=8000,
         metrics_multiprocess_mode=False,
@@ -163,19 +181,8 @@ def random_active_validator(
 
 
 @pytest.fixture
-async def remote_signer(
-    cli_args: CLIArgs,
-    _mocked_remote_signer_endpoints: None,
-) -> AsyncGenerator[RemoteSigner, None]:
-    async with RemoteSigner(url=cli_args.remote_signer_url) as remote_signer:
-        yield remote_signer
-
-
-@pytest.fixture
-async def scheduler(
-    event_loop: AbstractEventLoop,
-) -> AsyncGenerator[AsyncIOScheduler, None]:
-    _scheduler = AsyncIOScheduler(event_loop=event_loop)
+async def scheduler() -> AsyncGenerator[AsyncIOScheduler, None]:
+    _scheduler = AsyncIOScheduler(event_loop=asyncio.get_running_loop())
     _scheduler.start()
     yield _scheduler
     _scheduler.shutdown(wait=False)
@@ -187,17 +194,79 @@ def task_manager() -> TaskManager:
 
 
 @pytest.fixture
+def empty_db(tmp_path: Path) -> DB:
+    db = DB(data_dir=str(tmp_path))
+    db.run_migrations()
+    return db
+
+
+@pytest.fixture(scope="session")
+def process_pool_executor() -> ProcessPoolExecutor:
+    return ProcessPoolExecutor()
+
+
+@pytest.fixture
+async def keymanager(
+    empty_db: DB,
+    beacon_chain: BeaconChain,
+    cli_args: CLIArgs,
+    multi_beacon_node: MultiBeaconNode,
+    remote_signer_url: str,
+    process_pool_executor: ProcessPoolExecutor,
+    validators: list[ValidatorIndexPubkey],
+    _mocked_remote_signer_endpoints: None,
+) -> AsyncGenerator[Keymanager, None]:
+    async with Keymanager(
+        db=empty_db,
+        beacon_chain=beacon_chain,
+        multi_beacon_node=multi_beacon_node,
+        cli_args=cli_args,
+        process_pool_executor=process_pool_executor,
+    ) as keymanager:
+        yield keymanager
+
+
+@pytest.fixture
+async def signature_provider(
+    enable_keymanager_api: bool,
+    cli_args: CLIArgs,
+    keymanager: Keymanager,
+    remote_signer_url: str,
+    process_pool_executor: ProcessPoolExecutor,
+    validators: list[ValidatorIndexPubkey],
+) -> AsyncGenerator[SignatureProvider, None]:
+    if enable_keymanager_api:
+        # import the default fixture validators into the Keymanager provider
+        await keymanager.import_remote_keys(
+            remote_keys=[
+                SchemaKeymanagerAPI.RemoteKey(pubkey=v.pubkey, url=remote_signer_url)
+                for v in validators
+            ],
+        )
+        yield keymanager
+    else:
+        if cli_args.remote_signer_url is None:
+            raise RuntimeError(
+                "remote_signer_url is None despite disabled Keymanager API"
+            )
+        async with RemoteSigner(
+            url=cli_args.remote_signer_url, process_pool_executor=process_pool_executor
+        ) as remote_signer:
+            yield remote_signer
+
+
+@pytest.fixture
 async def validator_status_tracker(
     multi_beacon_node: MultiBeaconNode,
     beacon_chain: BeaconChain,
-    remote_signer: RemoteSigner,
+    signature_provider: SignatureProvider,
     scheduler: AsyncIOScheduler,
     task_manager: TaskManager,
 ) -> ValidatorStatusTrackerService:
     validator_status_tracker = ValidatorStatusTrackerService(
         multi_beacon_node=multi_beacon_node,
         beacon_chain=beacon_chain,
-        remote_signer=remote_signer,
+        signature_provider=signature_provider,
         scheduler=scheduler,
         task_manager=task_manager,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,9 +188,18 @@ async def scheduler() -> AsyncGenerator[AsyncIOScheduler, None]:
     _scheduler.shutdown(wait=False)
 
 
+@pytest.fixture
+def shutdown_event() -> asyncio.Event:
+    return asyncio.Event()
+
+
 @pytest.fixture(scope="session")
-def task_manager() -> TaskManager:
-    return TaskManager(shutdown_event=asyncio.Event())
+async def task_manager(
+    shutdown_event: asyncio.Event,
+) -> AsyncGenerator[TaskManager, None]:
+    t = TaskManager(shutdown_event=shutdown_event)
+    yield t
+    t.cancel_all()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import random
 import time
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncGenerator, Generator
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import milagro_bls_binding as bls
@@ -43,6 +44,8 @@ def cli_args(
     beacon_node_url: str,
     beacon_node_urls_proposal: list[str],
 ) -> CLIArgs:
+    tmp_dir = TemporaryDirectory()
+
     return CLIArgs(
         network=Network._TESTS,
         network_custom_config_path=None,
@@ -53,7 +56,7 @@ def cli_args(
             None, [beacon_node_url]
         ),
         fee_recipient="0x0000000000000000000000000000000000000000",
-        data_dir="/tmp/vero_tests",
+        data_dir=tmp_dir.name,
         use_external_builder=False,
         builder_boost_factor=90,
         graffiti=b"pytest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def enable_keymanager_api(request: pytest.FixtureRequest) -> bool:
     return getattr(request, "param", False)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def cli_args(
     remote_signer_url: str,
     beacon_node_url: str,
@@ -193,7 +193,7 @@ def shutdown_event() -> asyncio.Event:
     return asyncio.Event()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 async def task_manager(
     shutdown_event: asyncio.Event,
 ) -> AsyncGenerator[TaskManager, None]:
@@ -313,7 +313,7 @@ def genesis(spec: SpecElectra) -> Genesis:
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def beacon_chain(
     spec: SpecElectra, genesis: Genesis, task_manager: TaskManager
 ) -> BeaconChain:

--- a/tests/mock_api/base.py
+++ b/tests/mock_api/base.py
@@ -6,5 +6,6 @@ from aioresponses import aioresponses
 
 @pytest.fixture
 def mocked_responses() -> Generator[aioresponses, None, None]:
-    with aioresponses() as m:
+    # Passthrough for requests to Keymanager API
+    with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         yield m

--- a/tests/mock_api/beacon_node.py
+++ b/tests/mock_api/beacon_node.py
@@ -287,22 +287,27 @@ def _mocked_beacon_node_endpoints(
             ids = data["ids"]
             statuses = data["statuses"]
 
+            return_list = []
+            for validator in validators:
+                if validator.pubkey not in ids:
+                    continue
+
+                if statuses is not None and validator.status.value not in statuses:
+                    continue
+
+                return_list.append(
+                    SchemaBeaconAPI.ValidatorInfo(
+                        index=str(validator.index),
+                        status=validator.status,
+                        validator=SchemaBeaconAPI.Validator(pubkey=validator.pubkey),
+                    )
+                )
+
             return CallbackResult(
                 body=msgspec.json.encode(
                     SchemaBeaconAPI.GetStateValidatorsResponse(
                         execution_optimistic=False,
-                        data=[
-                            SchemaBeaconAPI.ValidatorInfo(
-                                index=str(validator.index),
-                                status=validator.status,
-                                validator=SchemaBeaconAPI.Validator(
-                                    pubkey=validator.pubkey
-                                ),
-                            )
-                            for validator in validators
-                            if validator.status.value in statuses
-                            and validator.pubkey in ids
-                        ],
+                        data=return_list,
                     )
                 )
             )

--- a/tests/providers/db/test_db.py
+++ b/tests/providers/db/test_db.py
@@ -1,25 +1,63 @@
-from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import pytest
 
 from providers import DB
 from providers.db.migrations import MIGRATIONS
 
 
-def test_db_run_migrations_empty_db() -> None:
-    tmp_dir = TemporaryDirectory()
-    db = DB(data_dir=tmp_dir.name)
+def test_db_run_migrations_empty_db(tmp_path: Path) -> None:
+    db = DB(data_dir=str(tmp_path))
     assert db.current_version == -1
     db.run_migrations()
-    assert db.current_version == 1
+    assert db.current_version == 2
     assert db.current_version == max(m.version for m in MIGRATIONS)
 
 
-def test_db_run_migrations_with_data_in_db() -> None:
-    tmp_dir = TemporaryDirectory()
-    db = DB(data_dir=tmp_dir.name)
+def test_db_run_migrations_with_data_in_db(tmp_path: Path) -> None:
+    db = DB(data_dir=str(tmp_path))
     assert db.current_version == -1
     db.run_migration_statements(migration=next(m for m in MIGRATIONS if m.version == 1))
     assert db.current_version == 1
 
+    db.run_migration_statements(migration=next(m for m in MIGRATIONS if m.version == 2))
+    assert db.current_version == 2
+    data = [
+        ("0x" + "a" * 96, "http://remote-signer-1:9000", None, None, None),
+        (
+            "0x" + "b" * 96,
+            "http://remote-signer-1:9000",
+            "0x" + "a" * 40,
+            "50000000",
+            "custom-graffiti",
+        ),
+        ("0x" + "c" * 96, "http://remote-signer-2:9000", "0x" + "0" * 40, None, None),
+        ("0x" + "d" * 96, "http://remote-signer-2:9000", None, "100000000", None),
+        ("0x" + "e" * 96, "http://remote-signer-2:9000", None, None, "my-graffiti"),
+    ]
+    with db.connection as conn:
+        conn.executemany("""INSERT INTO keymanager_data VALUES (?, ?, ?, ?, ?)""", data)
+
     # Add data to tables here when you introduce new tables in a DB migration
 
     assert db.current_version == max(m.version for m in MIGRATIONS)
+
+
+def test_too_many_host_params(tmp_path: Path) -> None:
+    db = DB(data_dir=str(tmp_path))
+    db.run_migrations()
+
+    parameters = [str(i) for i in range(50_000)]
+
+    with pytest.raises(ValueError, match=r"Too many host parameters provided"):
+        db.fetch_all(
+            f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in parameters)});",
+            parameters=parameters,
+        )
+
+    # Smaller batches work just fine
+    for batch in db.batch_host_parameters(parameters):
+        db.fetch_all(
+            f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in batch)});",
+            parameters=batch,
+        )

--- a/tests/providers/db/test_db.py
+++ b/tests/providers/db/test_db.py
@@ -1,0 +1,25 @@
+from tempfile import TemporaryDirectory
+
+from providers import DB
+from providers.db.migrations import MIGRATIONS
+
+
+def test_db_run_migrations_empty_db() -> None:
+    tmp_dir = TemporaryDirectory()
+    db = DB(data_dir=tmp_dir.name)
+    assert db.current_version == -1
+    db.run_migrations()
+    assert db.current_version == 1
+    assert db.current_version == max(m.version for m in MIGRATIONS)
+
+
+def test_db_run_migrations_with_data_in_db() -> None:
+    tmp_dir = TemporaryDirectory()
+    db = DB(data_dir=tmp_dir.name)
+    assert db.current_version == -1
+    db.run_migration_statements(migration=next(m for m in MIGRATIONS if m.version == 1))
+    assert db.current_version == 1
+
+    # Add data to tables here when you introduce new tables in a DB migration
+
+    assert db.current_version == max(m.version for m in MIGRATIONS)

--- a/tests/providers/test_keymanager.py
+++ b/tests/providers/test_keymanager.py
@@ -1,0 +1,49 @@
+import os
+import tracemalloc
+
+from providers import Keymanager
+from schemas.keymanager_api import RemoteKey
+
+
+async def test_keymanager_memory_usage(
+    keymanager: Keymanager,
+) -> None:
+    """
+    We load 1,000 keys with random metadata into Keymanager
+    and check that memory usage is within reason.
+    """
+    n = 1_000
+    pubkeys = ["0x" + os.urandom(48).hex() for _ in range(n)]
+
+    tracemalloc.start()
+    start_snapshot = tracemalloc.take_snapshot()
+
+    await keymanager.import_remote_keys(
+        remote_keys=[
+            RemoteKey(
+                pubkey=pk,
+                url=f"http://signer-{idx}",
+            )
+            for idx, pk in enumerate(pubkeys)
+        ]
+    )
+
+    fr = "0x" + os.urandom(20).hex()
+    gl = str(100_000_000)
+    graffiti = "0x" + os.urandom(100).hex()
+    for pk in pubkeys:
+        keymanager.set_fee_recipient(pubkey=pk, fee_recipient=fr)
+        keymanager.set_gas_limit(pubkey=pk, gas_limit=gl)
+        keymanager.set_graffiti(pubkey=pk, graffiti=graffiti)
+
+    end_snapshot = tracemalloc.take_snapshot()
+
+    # Compare memory usage
+    diff = end_snapshot.compare_to(start_snapshot, "lineno")
+
+    total_memory_increase = sum(d.size_diff for d in diff)
+    per_key_memory = total_memory_increase / n
+
+    # Every key with all of its metadata and instantiated remote signer
+    # should use about 15KiB of memory
+    assert per_key_memory / 1024 < 20

--- a/tests/providers/test_multi_beacon_node.py
+++ b/tests/providers/test_multi_beacon_node.py
@@ -5,6 +5,7 @@ when multiple beacon nodes are provided to it. That includes:
 - requesting sync committee contributions from all beacon nodes and returning the best one
 """
 
+import contextlib
 import os
 import re
 from copy import deepcopy
@@ -86,16 +87,9 @@ async def test_initialize(
         _process_attestation_consensus_threshold(None, beacon_node_urls)
     )
 
-    mbn = MultiBeaconNode(
-        beacon_node_urls=beacon_node_urls,
-        beacon_node_urls_proposal=[],
-        spec=spec,
-        scheduler=scheduler,
-        task_manager=task_manager,
-        cli_args=_cli_args_for_test,
-    )
+    async with contextlib.AsyncExitStack() as exit_stack:
+        m = exit_stack.enter_context(aioresponses())
 
-    with aioresponses() as m:
         for _url, beacon_node_available in zip(
             beacon_node_urls,
             beacon_node_availabilities,
@@ -137,16 +131,22 @@ async def test_initialize(
                     exception=ValueError("Beacon node unavailable"),
                 )
 
+        mbn_base = MultiBeaconNode(
+            beacon_node_urls=beacon_node_urls,
+            beacon_node_urls_proposal=[],
+            spec=spec,
+            scheduler=scheduler,
+            task_manager=task_manager,
+            cli_args=_cli_args_for_test,
+        )
         if expected_initialization_success:
-            await mbn.initialize()
+            await exit_stack.enter_async_context(mbn_base)
         else:
             with pytest.raises(
                 RuntimeError,
                 match="Failed to fully initialize a sufficient amount of beacon nodes",
             ):
-                await mbn.initialize()
-
-    await mbn.__aexit__(None, None, None)
+                await exit_stack.enter_async_context(mbn_base)
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/test_multi_beacon_node.py
+++ b/tests/providers/test_multi_beacon_node.py
@@ -198,9 +198,7 @@ async def test_get_aggregate_attestation(
                     beacon_chain.MAX_VALIDATORS_PER_COMMITTEE
                     * beacon_chain.MAX_COMMITTEES_PER_SLOT
                 )
-                agg_bits_to_return = Bitlist[bitlist_length](
-                    False for _ in range(bitlist_length)
-                )
+                agg_bits_to_return = Bitlist[bitlist_length](False for _ in range(10))
                 for idx in range(number_of_attesting_indices):
                     agg_bits_to_return[idx] = True
                 _callback = partial(

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs
-from providers import BeaconChain, MultiBeaconNode, RemoteSigner
+from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvider
 from services import (
     AttestationService,
     BlockProposalService,
@@ -16,7 +16,8 @@ from tasks import TaskManager
 def validator_duty_service_options(
     multi_beacon_node: MultiBeaconNode,
     beacon_chain: BeaconChain,
-    remote_signer: RemoteSigner,
+    signature_provider: SignatureProvider,
+    keymanager: Keymanager,
     validator_status_tracker: ValidatorStatusTrackerService,
     scheduler: AsyncIOScheduler,
     task_manager: TaskManager,
@@ -25,7 +26,8 @@ def validator_duty_service_options(
     return ValidatorDutyServiceOptions(
         multi_beacon_node=multi_beacon_node,
         beacon_chain=beacon_chain,
-        remote_signer=remote_signer,
+        signature_provider=signature_provider,
+        keymanager=keymanager,
         validator_status_tracker_service=validator_status_tracker,
         scheduler=scheduler,
         task_manager=task_manager,

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -6,6 +6,7 @@ from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvide
 from services import (
     AttestationService,
     BlockProposalService,
+    SyncCommitteeService,
     ValidatorStatusTrackerService,
 )
 from services.validator_duty_service import ValidatorDutyServiceOptions
@@ -47,3 +48,10 @@ def block_proposal_service(
     validator_duty_service_options: ValidatorDutyServiceOptions,
 ) -> BlockProposalService:
     return BlockProposalService(**validator_duty_service_options)
+
+
+@pytest.fixture
+def sync_committee_service(
+    validator_duty_service_options: ValidatorDutyServiceOptions,
+) -> SyncCommitteeService:
+    return SyncCommitteeService(**validator_duty_service_options)

--- a/tests/services/test_attestation.py
+++ b/tests/services/test_attestation.py
@@ -15,6 +15,14 @@ from services.attestation import (
 from spec.attestation import AttestationData
 
 
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
 async def test_update_duties(attestation_service: AttestationService) -> None:
     # This test just checks that no exception is thrown
     assert len(attestation_service.attester_duties) == 0
@@ -30,11 +38,20 @@ async def test_update_duties(attestation_service: AttestationService) -> None:
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
 async def test_attest_if_not_yet_attested(
     attestation_service: AttestationService,
     beacon_chain: BeaconChain,
     validators: list[ValidatorIndexPubkey],
     fork_version: ForkVersion,
+    enable_keymanager_api: bool,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Populate the service with an attester duty
@@ -100,10 +117,19 @@ async def test_attest_to_invalid_slot(
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
 async def test_aggregate_attestations(
     attestation_service: AttestationService,
     beacon_chain: BeaconChain,
     fork_version: ForkVersion,
+    enable_keymanager_api: bool,
     validators: list[ValidatorIndexPubkey],
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/services/test_sync_committee.py
+++ b/tests/services/test_sync_committee.py
@@ -20,17 +20,36 @@ def sync_committee_service(
     return SyncCommitteeService(**validator_duty_service_options)
 
 
-async def test_update_duties(sync_committee_service: SyncCommitteeService) -> None:
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
+async def test_update_duties(
+    sync_committee_service: SyncCommitteeService, enable_keymanager_api: bool
+) -> None:
     # This test just checks that no exception is thrown
     assert len(sync_committee_service.sync_duties) == 0
     await sync_committee_service._update_duties()
     assert len(sync_committee_service.sync_duties) > 0
 
 
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
 async def test_produce_sync_message_if_not_yet_produced(
     sync_committee_service: SyncCommitteeService,
     beacon_chain: BeaconChain,
     random_active_validator: ValidatorIndexPubkey,
+    enable_keymanager_api: bool,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Populate the service with a sync duty
@@ -63,10 +82,19 @@ async def test_produce_sync_message_if_not_yet_produced(
     assert sync_committee_service._last_slot_duty_completed_for == duty_slot
 
 
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
 async def test_aggregate_sync_messages(
     sync_committee_service: SyncCommitteeService,
     beacon_chain: BeaconChain,
     random_active_validator: ValidatorIndexPubkey,
+    enable_keymanager_api: bool,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # Populate the service with a sync contribution duty

--- a/tests/services/test_sync_committee.py
+++ b/tests/services/test_sync_committee.py
@@ -10,14 +10,6 @@ from services.sync_committee import (
     _VC_PUBLISHED_SYNC_COMMITTEE_CONTRIBUTIONS,
     _VC_PUBLISHED_SYNC_COMMITTEE_MESSAGES,
 )
-from services.validator_duty_service import ValidatorDutyServiceOptions
-
-
-@pytest.fixture
-def sync_committee_service(
-    validator_duty_service_options: ValidatorDutyServiceOptions,
-) -> SyncCommitteeService:
-    return SyncCommitteeService(**validator_duty_service_options)
 
 
 @pytest.mark.parametrize(

--- a/tests/services/test_validator_status_tracker.py
+++ b/tests/services/test_validator_status_tracker.py
@@ -41,7 +41,7 @@ def _reset_slashing_detected_metric() -> None:
                 ),
             ),
             False,
-            id="Attester slashings for a validator not managed by 'us' (#10, #11)",
+            id="Attester slashings for validators not managed by 'us' (#10, #11)",
         ),
         pytest.param(
             SchemaBeaconAPI.ProposerSlashingEvent(
@@ -73,7 +73,7 @@ def _reset_slashing_detected_metric() -> None:
                 ),
             ),
             False,
-            id="Proposer slashing for 'our' validator (#4)",
+            id="Proposer slashing for a validator not managed by 'us' (#10)",
         ),
     ],
 )

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -376,10 +376,10 @@ from spec.configs import Network
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
                 "--enable-keymanager-api",
             ],
-            None,
             "argument --enable-keymanager-api: not allowed with argument --remote-signer-url",
             {},
-            id="mutually exclusive group - key source",
+            [],
+            id="Mutually exclusive group - key source",
         ),
         pytest.param(
             [
@@ -389,9 +389,17 @@ from spec.configs import Network
                 "--enable-keymanager-api",
             ],
             None,
-            None,
-            {},
-            id="Keymanager API enabled - no remote signer",
+            {
+                "enable_keymanager_api": True,
+                "keymanager_api_token_file_path": Path(
+                    "/vero/data/keymanager-api-token.txt"
+                ),
+            },
+            [
+                "enable_keymanager_api: True",
+                "keymanager_api_token_file_path: /vero/data/keymanager-api-token.txt",
+            ],
+            id="--enable-keymanager-api (no --remote-signer-url)",
         ),
     ],
 )

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -484,6 +484,8 @@ def test_parse_cli_args_full_set() -> None:
     parsed_args = parse_cli_args(list_of_args)
 
     for action in get_parser()._actions:
+        # Ignoring missing --enable-keymanager-api flag since it's
+        # mutually exclusive with --remote-signer-url
         if action.dest in ("help", "enable_keymanager_api"):
             continue
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,145 @@
+import asyncio
+import cProfile
+import logging
+import os
+import pstats
+import signal
+import time
+from _lsprof import profiler_entry
+from collections.abc import Generator
+
+import pytest
+
+from args import CLIArgs
+from main import main
+
+
+@pytest.fixture
+def _profile_program_run() -> Generator[None, None, None]:
+    # CI environments report artificially high CPU usage due to virtualization
+    # -> skipping the check of CPU usage there
+    if os.getenv("CI") == "true":
+        yield
+        return
+
+    def is_idle_stat(stat: profiler_entry) -> bool:
+        """
+        Some stats are treated as 'idle time' when evaluating CPU usage,
+        since the program is waiting on I/O and not actively consuming CPU.
+        """
+        if isinstance(stat.code, str):
+            return any(
+                substr in stat.code
+                for substr in (
+                    "of 'select.kqueue' objects>",
+                    "of 'select.poll' objects>",
+                )
+            )
+        return False
+
+    prof = cProfile.Profile()
+    with prof:
+        start_wall_time = time.perf_counter()
+        yield
+        wall_time = time.perf_counter() - start_wall_time
+
+    idle_time = sum(s.totaltime for s in prof.getstats() if is_idle_stat(s))
+    adjusted_cpu_time = pstats.Stats(prof).total_tt - idle_time  # type: ignore[attr-defined]
+    cpu_utilization = adjusted_cpu_time / wall_time
+
+    # Vero should be able to perform all its duties without
+    # keeping the event loop busy 100% of the time, even with
+    # the very short 1s slot time in the test config.
+    assert 0.05 < cpu_utilization < 0.5
+
+
+@pytest.mark.parametrize(
+    "enable_keymanager_api",
+    [
+        pytest.param(False, id="signature_provider: RemoteSigner"),
+        pytest.param(True, id="signature_provider: Keymanager"),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("_mocked_beacon_node_endpoints")
+@pytest.mark.usefixtures("_mocked_remote_signer_endpoints")
+@pytest.mark.usefixtures("_profile_program_run")
+async def test_lifecycle(
+    cli_args: CLIArgs,
+    shutdown_event: asyncio.Event,
+    enable_keymanager_api: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Sanity check that Vero can start running, perform its duties and shut down cleanly.
+    """
+    run_services_task = asyncio.create_task(
+        main(
+            cli_args=cli_args,
+            shutdown_event=shutdown_event,
+        )
+    )
+
+    # Wait for expected log lines to appear
+    required_log_lines = [
+        "Initialized beacon node",
+        "Current slot: ",
+        "Initialized validator status tracker",
+        "Started validator duty services",
+        "Subscribing to events",
+        "Updated duties",
+        "Published block for slot",
+        "Published attestations for slot",
+        "Published sync committee messages for slot",
+    ]
+
+    if enable_keymanager_api:
+        # Slightly fewer checks for this mode since it's not that easy
+        # to register validator keys from inside this test
+        for line in (
+            "Updated duties",
+            "Published block for slot",
+            "Published attestations for slot",
+            "Published sync committee messages for slot",
+        ):
+            required_log_lines.remove(line)
+
+        required_log_lines.append("No active or pending validators detected")
+
+    timeout = 5
+    start = asyncio.get_running_loop().time()
+
+    all_lines_present = False
+    while asyncio.get_running_loop().time() - start < timeout:
+        await asyncio.sleep(0.2)
+
+        # Check if every required substring appears at least once in the captured logs
+        if all(
+            any(line in message for message in caplog.messages)
+            for line in required_log_lines
+        ):
+            all_lines_present = True
+            break
+
+    assert all_lines_present, (
+        f"Log lines not found: {[line for line in required_log_lines if not any(line in m for m in caplog.messages)]}"
+    )
+
+    # Make sure no errors occurred
+    err_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+
+    for record in err_records:
+        # Event stream is not mocked
+        if "Error occurred while processing beacon node events" in record.message:
+            continue
+
+        pytest.fail(f"Error occurred: {record.message}")
+
+    # Send SIGTERM signal to process to initiate a clean shutdown
+    os.kill(os.getpid(), signal.SIGTERM)
+
+    await shutdown_event.wait()
+    await run_services_task
+
+    assert any("Received shutdown signal SIGTERM" in m for m in caplog.messages)
+    assert any("Shutting down" in m for m in caplog.messages)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,7 +50,7 @@ def _profile_program_run() -> Generator[None, None, None]:
     # Vero should be able to perform all its duties without
     # keeping the event loop busy 100% of the time, even with
     # the very short 1s slot time in the test config.
-    assert 0.05 < cpu_utilization < 0.5
+    assert 0.02 < cpu_utilization < 0.5
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -712,6 +712,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-aiohttp"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4b/d326890c153f2c4ce1bf45d07683c08c10a1766058a22934620bc6ac6592/pytest_aiohttp-1.1.0.tar.gz", hash = "sha256:147de8cb164f3fc9d7196967f109ab3c0b93ea3463ab50631e56438eab7b5adc", size = 12842 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/0f/e6af71c02e0f1098eaf7d2dbf3ffdf0a69fc1e0ef174f96af05cef161f1b/pytest_aiohttp-1.1.0-py3-none-any.whl", hash = "sha256:f39a11693a0dce08dd6c542d241e199dd8047a6e6596b2bcfa60d373f143456d", size = 8932 },
+]
+
+[[package]]
 name = "pytest-asyncio"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +837,7 @@ dev = [
     { name = "milagro-bls-binding" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
 ]
@@ -846,6 +861,7 @@ dev = [
     { name = "milagro-bls-binding", specifier = ">=1.9.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-aiohttp", specifier = ">=1.1.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
 ]


### PR DESCRIPTION
Adds a `Keymanager` provider to Vero as a new, mutually exclusive option to the existing `RemoteSigner` provider which loads all keys from a single remote signer.

This required adding a SQLite database that stores the metadata needed by the `Keymanager` provider.

Initially I implemented this in a way where all data was loaded on-demand from the database file whenever it was needed.

However, since DB access is synchronous this could lead to issues if used with higher numbers of validators. Therefore I changed the implementation to track all `Keymanager` metadata in-memory and only read/write to the database when strictly necessary:

- when starting up - to load the metadata into memory
- when handling API requests - to persist the required changes

Tested on a 6k-key Holešky node and a 3k-key Gnosis node – no issues discovered.

Resolves https://github.com/serenita-org/vero/issues/6