### PR TITLE
docs: fix incorrect CLI flag prefix in example

### DIFF
--- a/docs/running_vero.md
+++ b/docs/running_vero.md
@@ -149,7 +149,7 @@ ___
 The logging level to use, one of `CRITICAL,ERROR,WARNING,INFO,DEBUG`. Defaults to `INFO`.
 ___
 
-#### `----DANGER----disable-slashing-detection`
+#### `---DANGER----disable-slashing-detection`
 
 **_!!! This flag is extremely dangerous and should not be provided to Vero under normal circumstances!!!_**
 


### PR DESCRIPTION
fixed a typo in the flag example — there was an extra dash at the beginning. It should be `---DANGER---disable-slashing-detection`, not `----DANGER---disable-slashing-detection`.  

p.s. this was causing issues with CLI parsing since the parser expects `--` as the correct flag prefix.