### PR TITLE
Tag only stable Vero versions as `latest`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,11 +30,13 @@ jobs:
       id: docker_metadata
       uses: docker/metadata-action@v5
       with:
-        images: |
-          ghcr.io/${{ github.repository_owner }}/vero
+        images: ghcr.io/${{ github.repository_owner }}/vero
         tags: |
+          # reflects the last commit on the `master` branch
           type=ref,event=branch
-          type=ref,event=tag
+          # tags release images as vX.Y.Z
+          # tags _only_ stable releases as `latest`
+          type=semver,pattern={{version}},prefix=v
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3


### PR DESCRIPTION
Currently CI is tagging all `v*` tags as the `latest` vero release.

This PR changes that to only tag stable releases as `latest`. Release candidates/alphas/betas will still be built and tagged `vX.Y.Z-{specifier}` but not as `latest`.