### PR TITLE
Allow any 0.6.x uv version to install dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM
 "tests/conftest.py" = ["F401", "F403", "F811", "I"]
 
 [tool.uv]
-required-version = "==0.6.13"
+required-version = "~=0.6.5"
 
 [tool.uv.pip]
 generate-hashes = true


### PR DESCRIPTION
For better backwards compatibility with e.g. eth-docker that shouldn't need to track every minor change to our Dockerfile.