### PR TITLE
Produce a block even if highest returned block value is 0

### DIFF
--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -339,7 +339,7 @@ class MultiBeaconNode:
         }
         pending = tasks
 
-        best_block_value = 0
+        best_block_value = -1
         best_block_response = None
         start_time = asyncio.get_running_loop().time()
         remaining_timeout = timeout


### PR DESCRIPTION
Edge case discovered on a local devnet. In the case where all blocks returned by the connected beacon nodes have a reported value of 0 Vero failed to produce a block.