### PR TITLE
Use faster `time.time` over `datetime.now` where possible

### DIFF
--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -1,6 +1,6 @@
 import asyncio
-import datetime
 import logging
+import time
 from collections import defaultdict
 from typing import Unpack
 
@@ -201,7 +201,7 @@ class BlockProposalService(ValidatorDutyService):
             if v.index % slots_per_epoch == current_slot % slots_per_epoch
         ]
 
-        _timestamp = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+        _timestamp = int(time.time())
 
         for i in range(0, len(validators_to_register), _batch_size):
             validator_batch = validators_to_register[i : i + _batch_size]

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -63,10 +63,10 @@ class SyncCommitteeService(ValidatorDutyService):
         # Schedule sync message job at the deadline in case
         # it is not triggered earlier by a new HeadEvent,
         # aiming to produce it 1/3 into the slot at the latest.
-        _produce_deadline = self.beacon_chain.get_datetime_for_slot(
-            slot=slot
-        ) + datetime.timedelta(
-            seconds=int(self.beacon_chain.spec.SECONDS_PER_SLOT) / INTERVALS_PER_SLOT,
+        _produce_deadline = datetime.datetime.fromtimestamp(
+            timestamp=self.beacon_chain.get_timestamp_for_slot(slot)
+            + int(self.beacon_chain.spec.SECONDS_PER_SLOT) / INTERVALS_PER_SLOT,
+            tz=datetime.UTC,
         )
 
         self.scheduler.add_job(
@@ -308,12 +308,10 @@ class SyncCommitteeService(ValidatorDutyService):
             )
 
         # Sign and submit aggregated sync committee contributions at 2/3 of the slot
-        aggregation_run_time = self.beacon_chain.get_datetime_for_slot(
-            duty_slot,
-        ) + datetime.timedelta(
-            seconds=2
-            * int(self.beacon_chain.spec.SECONDS_PER_SLOT)
-            / INTERVALS_PER_SLOT,
+        aggregation_run_time = datetime.datetime.fromtimestamp(
+            timestamp=self.beacon_chain.get_timestamp_for_slot(duty_slot)
+            + 2 * int(self.spec.SECONDS_PER_SLOT) / INTERVALS_PER_SLOT,
+            tz=datetime.UTC,
         )
         self.scheduler.add_job(
             self.aggregate_sync_messages,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
-import datetime
 import random
+import time
 from asyncio import AbstractEventLoop
 from collections.abc import AsyncGenerator, Generator
 from unittest import mock
@@ -226,11 +226,7 @@ async def multi_beacon_node(
 def genesis(spec: SpecElectra) -> Genesis:
     # Fake genesis 1 hour ago
     return Genesis(
-        genesis_time=int(
-            (
-                datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
-            ).timestamp()
-        ),
+        genesis_time=int(time.time() - 3600),
         genesis_validators_root="0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
         genesis_fork_version=spec.GENESIS_FORK_VERSION,
     )

--- a/tests/providers/test_multi_beacon_node_attestation_consensus.py
+++ b/tests/providers/test_multi_beacon_node_attestation_consensus.py
@@ -3,8 +3,8 @@ when multiple beacon nodes are provided to it. That includes:
 - coming to consensus on attestation data to sign
 """
 
-import datetime
 import re
+import time
 from collections import Counter
 from functools import partial
 
@@ -218,8 +218,7 @@ async def test_produce_attestation_data(
                 match="Failed to reach consensus on attestation data",
             ):
                 _ = await multi_beacon_node_three_inited_nodes.produce_attestation_data(
-                    deadline=datetime.datetime.now(tz=datetime.UTC)
-                    + datetime.timedelta(seconds=0.1),
+                    deadline_timestamp=time.time() + 0.1,
                     slot=123,
                     committee_index=3,
                     head_event=head_event,
@@ -228,8 +227,7 @@ async def test_produce_attestation_data(
 
         # We expect to reach consensus on attestation data here
         att_data = await multi_beacon_node_three_inited_nodes.produce_attestation_data(
-            deadline=datetime.datetime.now(tz=datetime.UTC)
-            + datetime.timedelta(seconds=1),
+            deadline_timestamp=time.time() + 1,
             slot=123,
             committee_index=3,
             head_event=head_event,


### PR DESCRIPTION
Profiling showed computing the `BeaconChain.current_slot` property was taking about 6% of total CPU time, it is accessed from a lot of places.

This PR changes it to use the ~4x faster `time.time()` instead of instantiating a complex datetime object all the time. Other instances of datetime were also changed to time wherever possible.