### PR TITLE
Track request response bytes

### DIFF
--- a/grafana/vero-detailed.json
+++ b/grafana/vero-detailed.json
@@ -50,8 +50,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -82,7 +81,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -116,8 +115,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -148,7 +146,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -184,8 +182,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -216,7 +213,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -250,8 +247,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -282,7 +278,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -317,8 +313,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -349,7 +344,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -417,8 +412,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -443,11 +437,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -484,8 +479,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -577,7 +571,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -638,8 +632,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -675,7 +668,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -726,8 +719,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -762,7 +754,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -798,8 +790,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -835,7 +826,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -870,8 +861,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -902,7 +892,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -932,6 +922,7 @@
             "mode": "thresholds"
           },
           "custom": {
+            "axisPlacement": "auto",
             "fillOpacity": 70,
             "hideFrom": {
               "legend": false,
@@ -947,8 +938,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
+                "color": "red"
               },
               {
                 "color": "#EAB839",
@@ -982,11 +972,12 @@
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1034,6 +1025,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1156,7 +1148,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 19
           },
           "id": 28,
           "options": {
@@ -1170,11 +1162,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1289,12 +1282,18 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 40
           },
           "id": 33,
           "maxDataPoints": 50,
           "options": {
             "displayMode": "basic",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
             "maxVizHeight": 300,
             "minVizHeight": 16,
             "minVizWidth": 8,
@@ -1312,7 +1311,7 @@
             "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1357,7 +1356,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 48
           },
           "id": 19,
           "maxDataPoints": 50,
@@ -1395,7 +1394,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1434,6 +1433,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 60,
                 "gradientMode": "none",
@@ -1479,7 +1479,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 62
           },
           "id": 273,
           "options": {
@@ -1490,10 +1490,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1538,7 +1540,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 62
           },
           "id": 274,
           "options": {
@@ -1560,11 +1562,12 @@
               "values": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1619,6 +1622,7 @@
                 "axisSoftMax": 4,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1707,7 +1711,7 @@
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 35
+            "y": 20
           },
           "id": 230,
           "maxDataPoints": 100,
@@ -1719,11 +1723,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1790,6 +1795,7 @@
                 "axisSoftMax": 8,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -1878,7 +1884,7 @@
             "h": 6,
             "w": 5,
             "x": 4,
-            "y": 35
+            "y": 20
           },
           "id": 214,
           "maxDataPoints": 100,
@@ -1890,11 +1896,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -1961,6 +1968,7 @@
                 "axisSoftMax": 8,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2049,7 +2057,7 @@
             "h": 6,
             "w": 5,
             "x": 9,
-            "y": 35
+            "y": 20
           },
           "id": 215,
           "maxDataPoints": 100,
@@ -2061,11 +2069,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2132,6 +2141,7 @@
                 "axisSoftMax": 12,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2220,7 +2230,7 @@
             "h": 6,
             "w": 5,
             "x": 14,
-            "y": 35
+            "y": 20
           },
           "id": 216,
           "maxDataPoints": 100,
@@ -2232,11 +2242,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2303,6 +2314,7 @@
                 "axisSoftMax": 12,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2391,7 +2403,7 @@
             "h": 6,
             "w": 5,
             "x": 19,
-            "y": 35
+            "y": 20
           },
           "id": 217,
           "maxDataPoints": 100,
@@ -2403,11 +2415,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2477,7 +2490,7 @@
             "h": 19,
             "w": 4,
             "x": 0,
-            "y": 41
+            "y": 40
           },
           "id": 24,
           "maxDataPoints": 10,
@@ -2515,7 +2528,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2560,7 +2573,7 @@
             "h": 19,
             "w": 5,
             "x": 4,
-            "y": 41
+            "y": 40
           },
           "id": 18,
           "maxDataPoints": 10,
@@ -2598,7 +2611,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2643,7 +2656,7 @@
             "h": 19,
             "w": 5,
             "x": 9,
-            "y": 41
+            "y": 40
           },
           "id": 22,
           "maxDataPoints": 10,
@@ -2681,7 +2694,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2726,7 +2739,7 @@
             "h": 19,
             "w": 5,
             "x": 14,
-            "y": 41
+            "y": 40
           },
           "id": 26,
           "maxDataPoints": 10,
@@ -2764,7 +2777,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2809,7 +2822,7 @@
             "h": 19,
             "w": 5,
             "x": 19,
-            "y": 41
+            "y": 40
           },
           "id": 23,
           "maxDataPoints": 10,
@@ -2847,7 +2860,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -2903,6 +2916,7 @@
                 "axisSoftMax": 4,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -2991,7 +3005,7 @@
             "h": 6,
             "w": 4,
             "x": 0,
-            "y": 61
+            "y": 97
           },
           "id": 181,
           "maxDataPoints": 100,
@@ -3003,11 +3017,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3074,6 +3089,7 @@
                 "axisSoftMax": 8,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3162,7 +3178,7 @@
             "h": 6,
             "w": 5,
             "x": 4,
-            "y": 61
+            "y": 97
           },
           "id": 198,
           "maxDataPoints": 100,
@@ -3174,11 +3190,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3245,6 +3262,7 @@
                 "axisSoftMax": 8,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3333,7 +3351,7 @@
             "h": 6,
             "w": 5,
             "x": 9,
-            "y": 61
+            "y": 97
           },
           "id": 199,
           "maxDataPoints": 100,
@@ -3345,11 +3363,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3416,6 +3435,7 @@
                 "axisSoftMax": 12,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3504,7 +3524,7 @@
             "h": 6,
             "w": 5,
             "x": 14,
-            "y": 61
+            "y": 97
           },
           "id": 200,
           "maxDataPoints": 100,
@@ -3516,11 +3536,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3587,6 +3608,7 @@
                 "axisSoftMax": 12,
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3675,7 +3697,7 @@
             "h": 6,
             "w": 5,
             "x": 19,
-            "y": 61
+            "y": 97
           },
           "id": 201,
           "maxDataPoints": 100,
@@ -3687,11 +3709,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3761,7 +3784,7 @@
             "h": 19,
             "w": 4,
             "x": 0,
-            "y": 67
+            "y": 103
           },
           "id": 82,
           "maxDataPoints": 10,
@@ -3799,7 +3822,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3844,7 +3867,7 @@
             "h": 19,
             "w": 5,
             "x": 4,
-            "y": 67
+            "y": 103
           },
           "id": 83,
           "maxDataPoints": 10,
@@ -3882,7 +3905,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -3927,7 +3950,7 @@
             "h": 19,
             "w": 5,
             "x": 9,
-            "y": 67
+            "y": 103
           },
           "id": 84,
           "maxDataPoints": 10,
@@ -3965,7 +3988,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4010,7 +4033,7 @@
             "h": 19,
             "w": 5,
             "x": 14,
-            "y": 67
+            "y": 103
           },
           "id": 85,
           "maxDataPoints": 10,
@@ -4048,7 +4071,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4093,7 +4116,7 @@
             "h": 19,
             "w": 5,
             "x": 19,
-            "y": 67
+            "y": 103
           },
           "id": 86,
           "maxDataPoints": 10,
@@ -4131,7 +4154,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4188,10 +4211,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
+            "h": 6,
             "w": 4,
             "x": 0,
-            "y": 30
+            "y": 123
           },
           "id": 131,
           "options": {
@@ -4211,7 +4234,7 @@
             "textMode": "name",
             "wideLayout": true
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4228,6 +4251,350 @@
           ],
           "title": "Version",
           "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 100
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 4,
+            "y": 123
+          },
+          "id": 60,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "beacon_node_score{instance=\"$instance\", host=~\"$beacon_node_host\"}",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Score",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Transmit"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed",
+                      "seriesBy": "last"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Receive"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 8,
+            "y": 123
+          },
+          "id": 299,
+          "interval": "1m",
+          "maxDataPoints": 100,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "irate(receive_bytes_total{service_type=\"beacon_node\", host=~\"$beacon_node_host\", instance=\"$instance\"}[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "recv {{host}}",
+              "range": true,
+              "refId": "Receive"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "irate(transmit_bytes_total{service_type=\"beacon_node\", host=~\"$beacon_node_host\", instance=\"$instance\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "trans {{host}}",
+              "range": true,
+              "refId": "Transmit"
+            }
+          ],
+          "title": "Network Traffic",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 70,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*Slashing.*/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 123
+          },
+          "id": 49,
+          "interval": "1m",
+          "maxDataPoints": 100,
+          "options": {
+            "colWidth": 0.9,
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "rowHeight": 0.9,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "round(increase(vc_processed_beacon_node_events_total{instance=\"$instance\", host=~\"$beacon_node_host\"}[$__interval])) > 0",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{ event_type }}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Processed beacon node events [$__interval]",
+          "type": "status-history"
         },
         {
           "datasource": {
@@ -4288,9 +4655,9 @@
           },
           "gridPos": {
             "h": 20,
-            "w": 10,
-            "x": 4,
-            "y": 30
+            "w": 12,
+            "x": 0,
+            "y": 129
           },
           "id": 7,
           "interval": "1m",
@@ -4303,12 +4670,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4386,9 +4754,9 @@
           },
           "gridPos": {
             "h": 20,
-            "w": 10,
-            "x": 14,
-            "y": 30
+            "w": 12,
+            "x": 12,
+            "y": 129
           },
           "id": 39,
           "maxDataPoints": 100,
@@ -4400,12 +4768,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4422,200 +4791,6 @@
           ],
           "title": "Request Duration",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "axisSoftMax": 100,
-                "axisSoftMin": 0,
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red"
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 100
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 16,
-            "w": 4,
-            "x": 0,
-            "y": 34
-          },
-          "id": 60,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "beacon_node_score{instance=\"$instance\", host=~\"$beacon_node_host\"}",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Score",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "fillOpacity": 70,
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 1
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/.*Slashing.*/"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "orange",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 42
-          },
-          "id": 49,
-          "interval": "1m",
-          "maxDataPoints": 100,
-          "options": {
-            "colWidth": 0.9,
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "rowHeight": 0.9,
-            "showValue": "never",
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "editorMode": "code",
-              "expr": "round(increase(vc_processed_beacon_node_events_total{instance=\"$instance\", host=~\"$beacon_node_host\"}[$__interval])) > 0",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{ event_type }}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Processed beacon node events [$__interval]",
-          "type": "status-history"
         },
         {
           "datasource": {
@@ -4679,7 +4854,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 149
           },
           "id": 243,
           "options": {
@@ -4690,11 +4865,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4775,7 +4951,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 149
           },
           "id": 256,
           "options": {
@@ -4786,11 +4962,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4834,7 +5011,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 157
           },
           "id": 294,
           "maxDataPoints": 100,
@@ -4872,7 +5049,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4917,7 +5094,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 157
           },
           "id": 295,
           "maxDataPoints": 100,
@@ -4955,7 +5132,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -4986,7 +5163,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 22
       },
       "id": 13,
       "panels": [
@@ -5009,6 +5186,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5051,7 +5229,7 @@
             "h": 14,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 25
           },
           "id": 69,
           "maxDataPoints": 100,
@@ -5063,11 +5241,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5113,6 +5293,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5153,9 +5334,9 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 6,
             "x": 12,
-            "y": 67
+            "y": 25
           },
           "id": 42,
           "maxDataPoints": 100,
@@ -5167,11 +5348,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5208,6 +5391,153 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Receive"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "Transmit"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 25
+          },
+          "id": 300,
+          "maxDataPoints": 100,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "maxHeight": 600,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "irate(receive_bytes_total{service_type=\"remote_signer\", instance=\"$instance\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "recv {{host}}",
+              "range": true,
+              "refId": "Receive"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "irate(transmit_bytes_total{service_type=\"remote_signer\", instance=\"$instance\"}[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "trans {{host}}",
+              "range": true,
+              "refId": "Transmit"
+            }
+          ],
+          "title": "Network Traffic",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5250,7 +5580,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 32
           },
           "id": 41,
           "maxDataPoints": 100,
@@ -5262,12 +5592,13 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "maxHeight": 600,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5305,7 +5636,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 23
       },
       "id": 38,
       "panels": [
@@ -5321,6 +5652,7 @@
                 "mode": "continuous-GrYlRd"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 70,
                 "hideFrom": {
                   "legend": false,
@@ -5346,7 +5678,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 68
+            "y": 398
           },
           "id": 36,
           "interval": "1m",
@@ -5361,11 +5693,12 @@
             "rowHeight": 0.9,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5393,7 +5726,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 24
       },
       "id": 31,
       "panels": [
@@ -5415,6 +5748,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5461,7 +5795,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 27
+            "y": 411
           },
           "id": 97,
           "options": {
@@ -5472,10 +5806,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5511,6 +5847,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5557,7 +5894,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 27
+            "y": 411
           },
           "id": 98,
           "options": {
@@ -5568,10 +5905,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5607,6 +5946,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -5649,7 +5989,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 27
+            "y": 411
           },
           "id": 120,
           "options": {
@@ -5660,10 +6000,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5717,7 +6059,7 @@
             "h": 2,
             "w": 6,
             "x": 18,
-            "y": 27
+            "y": 411
           },
           "id": 79,
           "options": {
@@ -5737,7 +6079,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5782,7 +6124,7 @@
             "h": 2,
             "w": 6,
             "x": 18,
-            "y": 29
+            "y": 413
           },
           "id": 291,
           "options": {
@@ -5802,7 +6144,7 @@
             "textMode": "name",
             "wideLayout": true
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5847,7 +6189,7 @@
             "h": 2,
             "w": 6,
             "x": 18,
-            "y": 31
+            "y": 415
           },
           "id": 292,
           "options": {
@@ -5867,7 +6209,7 @@
             "textMode": "name",
             "wideLayout": true
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5912,7 +6254,7 @@
             "h": 2,
             "w": 6,
             "x": 18,
-            "y": 33
+            "y": 417
           },
           "id": 293,
           "options": {
@@ -5932,7 +6274,7 @@
             "textMode": "name",
             "wideLayout": true
           },
-          "pluginVersion": "11.1.1",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -5969,6 +6311,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6015,7 +6358,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 419
           },
           "id": 30,
           "options": {
@@ -6026,10 +6369,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -6065,6 +6410,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6107,7 +6453,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 419
           },
           "id": 32,
           "options": {
@@ -6118,11 +6464,12 @@
               "showLegend": false
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "10.2.6",
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -6158,6 +6505,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6203,7 +6551,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 427
           },
           "id": 78,
           "options": {
@@ -6214,10 +6562,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "datasource": {
@@ -6242,7 +6592,7 @@
   ],
   "preload": false,
   "refresh": "1m",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -6318,6 +6668,5 @@
   "timezone": "",
   "title": "Vero - Detailed",
   "uid": "f3868b92-83fd-43a3-8d18-a74f35369590",
-  "version": 9,
-  "weekStart": ""
+  "version": 10
 }


### PR DESCRIPTION
Adds two new metrics - `receive_bytes_total` and `transmit_bytes_total` that keep track of the total amount of exchanged bytes:

<img width="248" alt="image" src="https://github.com/user-attachments/assets/bf0b26e8-9121-45da-849d-9930ce47cb7e" />
