### PR TITLE
Enforce unique hostnames for beacon node URLs

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -264,6 +264,22 @@ def parse_cli_args(args: Sequence[str]) -> CLIArgs:
                 min_values_required=1,
             )
         ]
+        if len({urlparse(bn_url).hostname for bn_url in beacon_node_urls}) != len(
+            beacon_node_urls
+        ):
+            parser.error("Beacon node URLs must have unique hostnames.")
+        beacon_node_urls_proposal = [
+            _validate_url(url)
+            for url in _validate_comma_separated_strings(
+                input_string=parsed_args.beacon_node_urls_proposal,
+                entity_name="proposal beacon node url",
+                min_values_required=0,
+            )
+        ]
+        if len(
+            {urlparse(bn_url).hostname for bn_url in beacon_node_urls_proposal}
+        ) != len(beacon_node_urls_proposal):
+            parser.error("Proposal beacon node URLs must have unique hostnames.")
         network = Network(parsed_args.network)
 
         validated_args = CLIArgs(
@@ -271,14 +287,7 @@ def parse_cli_args(args: Sequence[str]) -> CLIArgs:
             network_custom_config_path=parsed_args.network_custom_config_path,
             remote_signer_url=_validate_url(parsed_args.remote_signer_url),
             beacon_node_urls=beacon_node_urls,
-            beacon_node_urls_proposal=[
-                _validate_url(url)
-                for url in _validate_comma_separated_strings(
-                    input_string=parsed_args.beacon_node_urls_proposal,
-                    entity_name="proposal beacon node url",
-                    min_values_required=0,
-                )
-            ],
+            beacon_node_urls_proposal=beacon_node_urls_proposal,
             attestation_consensus_threshold=_process_attestation_consensus_threshold(
                 value=parsed_args.attestation_consensus_threshold,
                 beacon_node_urls=beacon_node_urls,

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -82,6 +82,18 @@ from spec.configs import Network
             [
                 "--network=hoodi",
                 "--remote-signer-url=http://signer:9000",
+                "--beacon-node-urls=http://beacon-node-1:5052,http://beacon-node-1:5053",
+                "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
+            ],
+            "Beacon node URLs must have unique hostnames",
+            {},
+            [],
+            id="--beacon-node-urls invalid input - duplicate hostname",
+        ),
+        pytest.param(
+            [
+                "--network=hoodi",
+                "--remote-signer-url=http://signer:9000",
                 "--beacon-node-urls=http://beacon-node:5052",
                 "--beacon-node-urls-proposal=http://beacon-node-prop:5052",
                 "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
@@ -96,6 +108,19 @@ from spec.configs import Network
                 "beacon_node_urls_proposal: http://beacon-node-prop:5052",
             ],
             id="--beacon-node-urls-proposal",
+        ),
+        pytest.param(
+            [
+                "--network=hoodi",
+                "--remote-signer-url=http://signer:9000",
+                "--beacon-node-urls=http://beacon-node-1:5052",
+                "--beacon-node-urls-proposal=http://beacon-node-1:5052,http://beacon-node-1:5053",
+                "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
+            ],
+            "Proposal beacon node URLs must have unique hostnames",
+            {},
+            [],
+            id="--beacon-node-urls-proposal invalid input - duplicate hostname",
         ),
         pytest.param(
             [


### PR DESCRIPTION
Vero assumes every beacon node has a unique hostname. This is reflected in multiple places, e.g. metrics.

It would probably make sense to change this in the future and allow for multiple beacon nodes on the same hostname, but until then, this change will make sure each beacon node connected to Vero has a unique hostname.