### PR TITLE
Cache validator duties on shutdown

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -213,7 +213,7 @@ async def run_services(
             block_proposal_service,
             sync_committee_service,
         ):
-            service.start()
+            await exit_stack.enter_async_context(service)
             validator_duty_services.append(service)
             beacon_chain.new_slot_handlers.append(service.on_new_slot)
         _logger.info("Started validator duty services")

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -12,11 +12,11 @@ from observability.event_loop import monitor_event_loop
 from providers import (
     DB,
     BeaconChain,
+    DutyCache,
     Keymanager,
     MultiBeaconNode,
     RemoteSigner,
 )
-from providers.duty_cache import DutyCacheProvider
 from schemas import SchemaBeaconAPI
 from services import (
     AttestationService,
@@ -199,7 +199,7 @@ async def run_services(
             beacon_chain=beacon_chain,
             signature_provider=signature_provider,
             keymanager=keymanager,
-            duty_cache_provider=DutyCacheProvider(data_dir=cli_args.data_dir),
+            duty_cache=DutyCache(data_dir=cli_args.data_dir),
             validator_status_tracker_service=validator_status_tracker_service,
             scheduler=scheduler,
             cli_args=cli_args,

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -16,6 +16,7 @@ from providers import (
     MultiBeaconNode,
     RemoteSigner,
 )
+from providers.duty_cache import DutyCacheProvider
 from schemas import SchemaBeaconAPI
 from services import (
     AttestationService,
@@ -198,6 +199,7 @@ async def run_services(
             beacon_chain=beacon_chain,
             signature_provider=signature_provider,
             keymanager=keymanager,
+            duty_cache_provider=DutyCacheProvider(data_dir=cli_args.data_dir),
             validator_status_tracker_service=validator_status_tracker_service,
             scheduler=scheduler,
             cli_args=cli_args,

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,6 +1,7 @@
 from .beacon_chain import BeaconChain
 from .beacon_node import BeaconNode
 from .db.db import DB
+from .duty_cache import DutyCache
 from .keymanager import Keymanager
 from .multi_beacon_node import MultiBeaconNode
 from .remote_signer import RemoteSigner
@@ -10,6 +11,7 @@ __all__ = [
     "DB",
     "BeaconChain",
     "BeaconNode",
+    "DutyCache",
     "Keymanager",
     "MultiBeaconNode",
     "RemoteSigner",

--- a/src/providers/duty_cache.py
+++ b/src/providers/duty_cache.py
@@ -20,7 +20,7 @@ def _save_bytes_to_fp(bytes_: bytes, fp: Path) -> None:
         f.write(bytes_)
 
 
-class DutyCacheProvider:
+class DutyCache:
     attester_duties_fname = "cache_attester_duties.json"
     attester_dep_roots_fname = "cache_attester_dependent_roots.json"
     proposer_duties_fname = "cache_proposer_duties.json"

--- a/src/providers/duty_cache.py
+++ b/src/providers/duty_cache.py
@@ -1,0 +1,108 @@
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import msgspec
+
+from schemas import SchemaBeaconAPI
+
+DutyDependentRoot = Annotated[str, msgspec.Meta(pattern="^0x[a-fA-F0-9]{64}$")]
+Epoch = Annotated[int, msgspec.Meta()]
+
+
+def _load_bytes_from_fp(fp: Path) -> bytes:
+    with Path.open(fp, "rb") as f:
+        return f.read()
+
+
+def _save_bytes_to_fp(bytes_: bytes, fp: Path) -> None:
+    with Path.open(fp, "wb") as f:
+        f.write(bytes_)
+
+
+class DutyCacheProvider:
+    attester_duties_fname = "cache_attester_duties.json"
+    attester_dep_roots_fname = "cache_attester_dependent_roots.json"
+    proposer_duties_fname = "cache_proposer_duties.json"
+    proposer_dep_roots_fname = "cache_proposer_dependent_roots.json"
+    sync_duties_fname = "cache_sync_duties.json"
+
+    def __init__(self, data_dir: str) -> None:
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.data_dir = Path(data_dir)
+        self.json_encoder = msgspec.json.Encoder()
+
+    def load_attester_duties(
+        self,
+    ) -> tuple[
+        dict[Epoch, set[SchemaBeaconAPI.AttesterDutyWithSelectionProof]],
+        dict[Epoch, DutyDependentRoot],
+    ]:
+        duties = msgspec.json.decode(
+            _load_bytes_from_fp(self.data_dir / self.attester_duties_fname),
+            type=dict[Epoch, set[SchemaBeaconAPI.AttesterDutyWithSelectionProof]],
+        )
+        dependent_roots = msgspec.json.decode(
+            _load_bytes_from_fp(self.data_dir / self.attester_dep_roots_fname),
+            type=dict[Epoch, DutyDependentRoot],
+        )
+        return duties, dependent_roots
+
+    def cache_attester_duties(
+        self,
+        duties: dict[Epoch, set[SchemaBeaconAPI.AttesterDutyWithSelectionProof]],
+        dependent_roots: dict[Epoch, DutyDependentRoot],
+    ) -> None:
+        _save_bytes_to_fp(
+            bytes_=self.json_encoder.encode(duties),
+            fp=self.data_dir / self.attester_duties_fname,
+        )
+        _save_bytes_to_fp(
+            bytes_=self.json_encoder.encode(dependent_roots),
+            fp=self.data_dir / self.attester_dep_roots_fname,
+        )
+
+    def load_proposer_duties(
+        self,
+    ) -> tuple[
+        dict[Epoch, set[SchemaBeaconAPI.ProposerDuty]],
+        dict[Epoch, DutyDependentRoot],
+    ]:
+        duties = msgspec.json.decode(
+            _load_bytes_from_fp(self.data_dir / self.proposer_duties_fname),
+            type=dict[Epoch, set[SchemaBeaconAPI.ProposerDuty]],
+        )
+        dependent_roots = msgspec.json.decode(
+            _load_bytes_from_fp(self.data_dir / self.proposer_dep_roots_fname),
+            type=dict[Epoch, DutyDependentRoot],
+        )
+        return duties, dependent_roots
+
+    def cache_proposer_duties(
+        self,
+        duties: dict[Epoch, set[SchemaBeaconAPI.ProposerDuty]],
+        dependent_roots: dict[Epoch, DutyDependentRoot],
+    ) -> None:
+        _save_bytes_to_fp(
+            bytes_=self.json_encoder.encode(duties),
+            fp=self.data_dir / self.proposer_duties_fname,
+        )
+        _save_bytes_to_fp(
+            bytes_=self.json_encoder.encode(dependent_roots),
+            fp=self.data_dir / self.proposer_dep_roots_fname,
+        )
+
+    def load_sync_duties(self) -> dict[Epoch, list[SchemaBeaconAPI.SyncDuty]]:
+        return msgspec.json.decode(
+            _load_bytes_from_fp(self.data_dir / self.sync_duties_fname),
+            type=dict[Epoch, list[SchemaBeaconAPI.SyncDuty]],
+        )
+
+    def cache_sync_duties(
+        self,
+        duties: dict[Epoch, list[SchemaBeaconAPI.SyncDuty]],
+    ) -> None:
+        _save_bytes_to_fp(
+            bytes_=self.json_encoder.encode(duties),
+            fp=self.data_dir / self.sync_duties_fname,
+        )

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -3,12 +3,10 @@ import contextlib
 import datetime
 import logging
 from collections import defaultdict
-from pathlib import Path
 from types import TracebackType
 from typing import Self, Unpack
 from uuid import uuid4
 
-import msgspec
 from apscheduler.jobstores.base import JobLookupError
 from opentelemetry import trace
 from opentelemetry.trace import (
@@ -74,23 +72,19 @@ class AttestationService(ValidatorDutyService):
 
     async def __aenter__(self) -> Self:
         try:
-            with Path.open(self._cache_path_duties, "rb") as f:
-                self.attester_duties = msgspec.json.decode(
-                    f.read(),
-                    type=dict[int, set[SchemaBeaconAPI.AttesterDutyWithSelectionProof]],
-                )
-            with Path.open(self._cache_path_dependent_roots, "rb") as f:
-                self.attester_duties_dependent_roots = msgspec.json.decode(
-                    f.read(), type=dict[int, str]
-                )
+            duties, dependent_roots = self.duty_cache_provider.load_attester_duties()
+            self.attester_duties = defaultdict(set, duties)
+            self.attester_duties_dependent_roots = dependent_roots
         except Exception as e:
             self.logger.warning(
                 f"Failed to load duties from cache: {e!r}",
                 exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
+        finally:
+            # The cached duties may be stale - call update_duties even if
+            # we loaded duties from cache
+            self.task_manager.submit_task(self.update_duties())
 
-        # We still call update_duties - the cached duties may be stale
-        self.task_manager.submit_task(self.update_duties())
         return self
 
     async def __aexit__(
@@ -100,10 +94,10 @@ class AttestationService(ValidatorDutyService):
         exc_tb: TracebackType | None,
     ) -> None:
         try:
-            with Path.open(self._cache_path_duties, "wb") as f:
-                f.write(self.json_encoder.encode(self.attester_duties))
-            with Path.open(self._cache_path_dependent_roots, "wb") as f:
-                f.write(self.json_encoder.encode(self.attester_duties_dependent_roots))
+            self.duty_cache_provider.cache_attester_duties(
+                duties=self.attester_duties,
+                dependent_roots=self.attester_duties_dependent_roots,
+            )
         except Exception as e:
             self.logger.warning(
                 f"Failed to cache duties: {e!r}",

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -72,7 +72,7 @@ class AttestationService(ValidatorDutyService):
 
     async def __aenter__(self) -> Self:
         try:
-            duties, dependent_roots = self.duty_cache_provider.load_attester_duties()
+            duties, dependent_roots = self.duty_cache.load_attester_duties()
             self.attester_duties = defaultdict(set, duties)
             self.attester_duties_dependent_roots = dependent_roots
         except Exception as e:
@@ -94,7 +94,7 @@ class AttestationService(ValidatorDutyService):
         exc_tb: TracebackType | None,
     ) -> None:
         try:
-            self.duty_cache_provider.cache_attester_duties(
+            self.duty_cache.cache_attester_duties(
                 duties=self.attester_duties,
                 dependent_roots=self.attester_duties_dependent_roots,
             )

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -76,10 +76,7 @@ class AttestationService(ValidatorDutyService):
             self.attester_duties = defaultdict(set, duties)
             self.attester_duties_dependent_roots = dependent_roots
         except Exception as e:
-            self.logger.warning(
-                f"Failed to load duties from cache: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.debug(f"Failed to load duties from cache: {e}")
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
@@ -99,10 +96,7 @@ class AttestationService(ValidatorDutyService):
                 dependent_roots=self.attester_duties_dependent_roots,
             )
         except Exception as e:
-            self.logger.warning(
-                f"Failed to cache duties: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.warning(f"Failed to cache duties: {e}")
 
     def has_duty_for_slot(self, slot: int) -> bool:
         epoch = slot // self.beacon_chain.SLOTS_PER_EPOCH

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -44,7 +44,7 @@ class BlockProposalService(ValidatorDutyService):
 
     async def __aenter__(self) -> Self:
         try:
-            duties, dependent_roots = self.duty_cache_provider.load_proposer_duties()
+            duties, dependent_roots = self.duty_cache.load_proposer_duties()
             self.proposer_duties = defaultdict(set, duties)
             self.proposer_duties_dependent_roots = dependent_roots
         except Exception as e:
@@ -67,7 +67,7 @@ class BlockProposalService(ValidatorDutyService):
         exc_tb: TracebackType | None,
     ) -> None:
         try:
-            self.duty_cache_provider.cache_proposer_duties(
+            self.duty_cache.cache_proposer_duties(
                 duties=self.proposer_duties,
                 dependent_roots=self.proposer_duties_dependent_roots,
             )

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -48,10 +48,7 @@ class BlockProposalService(ValidatorDutyService):
             self.proposer_duties = defaultdict(set, duties)
             self.proposer_duties_dependent_roots = dependent_roots
         except Exception as e:
-            self.logger.warning(
-                f"Failed to load duties from cache: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.debug(f"Failed to load duties from cache: {e}")
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
@@ -72,10 +69,7 @@ class BlockProposalService(ValidatorDutyService):
                 dependent_roots=self.proposer_duties_dependent_roots,
             )
         except Exception as e:
-            self.logger.warning(
-                f"Failed to cache duties: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.warning(f"Failed to cache duties: {e}")
 
     @property
     def next_duty_slot(self) -> int | None:

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -54,7 +54,7 @@ class SyncCommitteeService(ValidatorDutyService):
 
     async def __aenter__(self) -> Self:
         try:
-            duties = self.duty_cache_provider.load_sync_duties()
+            duties = self.duty_cache.load_sync_duties()
             self.sync_duties = defaultdict(list, duties)
         except Exception as e:
             self.logger.warning(
@@ -75,7 +75,7 @@ class SyncCommitteeService(ValidatorDutyService):
         exc_tb: TracebackType | None,
     ) -> None:
         try:
-            self.duty_cache_provider.cache_sync_duties(duties=self.sync_duties)
+            self.duty_cache.cache_sync_duties(duties=self.sync_duties)
         except Exception as e:
             self.logger.warning(
                 f"Failed to cache duties: {e!r}",

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -57,10 +57,7 @@ class SyncCommitteeService(ValidatorDutyService):
             duties = self.duty_cache.load_sync_duties()
             self.sync_duties = defaultdict(list, duties)
         except Exception as e:
-            self.logger.warning(
-                f"Failed to load duties from cache: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.debug(f"Failed to load duties from cache: {e}")
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
@@ -77,10 +74,7 @@ class SyncCommitteeService(ValidatorDutyService):
         try:
             self.duty_cache.cache_sync_duties(duties=self.sync_duties)
         except Exception as e:
-            self.logger.warning(
-                f"Failed to cache duties: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
-            )
+            self.logger.warning(f"Failed to cache duties: {e}")
 
     def has_duty_for_slot(self, slot: int) -> bool:
         epoch = slot // self.beacon_chain.SLOTS_PER_EPOCH

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -11,8 +11,13 @@ from prometheus_client import Histogram
 
 from args import CLIArgs
 from observability import ErrorType, get_shared_metrics
-from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvider
-from providers.duty_cache import DutyCacheProvider
+from providers import (
+    BeaconChain,
+    DutyCache,
+    Keymanager,
+    MultiBeaconNode,
+    SignatureProvider,
+)
 from schemas import SchemaBeaconAPI
 from tasks import TaskManager
 
@@ -35,7 +40,7 @@ class ValidatorDutyServiceOptions(TypedDict):
     beacon_chain: BeaconChain
     signature_provider: SignatureProvider
     keymanager: Keymanager
-    duty_cache_provider: DutyCacheProvider
+    duty_cache: DutyCache
     validator_status_tracker_service: "ValidatorStatusTrackerService"
     scheduler: AsyncIOScheduler
     task_manager: TaskManager
@@ -72,7 +77,7 @@ class ValidatorDutyService:
         self.beacon_chain = kwargs["beacon_chain"]
         self.signature_provider = kwargs["signature_provider"]
         self.keymanager = kwargs["keymanager"]
-        self.duty_cache_provider = kwargs["duty_cache_provider"]
+        self.duty_cache = kwargs["duty_cache"]
         self.validator_status_tracker_service = kwargs[
             "validator_status_tracker_service"
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ from providers import (
     Keymanager,
     DB,
     SignatureProvider,
+    DutyCache,
 )
-from providers.duty_cache import DutyCacheProvider
 from schemas import SchemaBeaconAPI, SchemaKeymanagerAPI
 from schemas.beacon_api import ForkVersion
 from schemas.validator import ACTIVE_STATUSES, ValidatorIndexPubkey
@@ -239,8 +239,8 @@ async def keymanager(
 
 
 @pytest.fixture
-def duty_cache_provider(cli_args: CLIArgs) -> DutyCacheProvider:
-    return DutyCacheProvider(data_dir=cli_args.data_dir)
+def duty_cache(cli_args: CLIArgs) -> DutyCache:
+    return DutyCache(data_dir=cli_args.data_dir)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from providers import (
     DB,
     SignatureProvider,
 )
+from providers.duty_cache import DutyCacheProvider
 from schemas import SchemaBeaconAPI, SchemaKeymanagerAPI
 from schemas.beacon_api import ForkVersion
 from schemas.validator import ACTIVE_STATUSES, ValidatorIndexPubkey
@@ -235,6 +236,11 @@ async def keymanager(
         process_pool_executor=process_pool_executor,
     ) as keymanager:
         yield keymanager
+
+
+@pytest.fixture
+def duty_cache_provider(cli_args: CLIArgs) -> DutyCacheProvider:
+    return DutyCacheProvider(data_dir=cli_args.data_dir)
 
 
 @pytest.fixture

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -2,8 +2,13 @@ import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs
-from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvider
-from providers.duty_cache import DutyCacheProvider
+from providers import (
+    BeaconChain,
+    DutyCache,
+    Keymanager,
+    MultiBeaconNode,
+    SignatureProvider,
+)
 from services import (
     AttestationService,
     BlockProposalService,
@@ -20,7 +25,7 @@ def validator_duty_service_options(
     beacon_chain: BeaconChain,
     signature_provider: SignatureProvider,
     keymanager: Keymanager,
-    duty_cache_provider: DutyCacheProvider,
+    duty_cache: DutyCache,
     validator_status_tracker: ValidatorStatusTrackerService,
     scheduler: AsyncIOScheduler,
     task_manager: TaskManager,
@@ -31,7 +36,7 @@ def validator_duty_service_options(
         beacon_chain=beacon_chain,
         signature_provider=signature_provider,
         keymanager=keymanager,
-        duty_cache_provider=duty_cache_provider,
+        duty_cache=duty_cache,
         validator_status_tracker_service=validator_status_tracker,
         scheduler=scheduler,
         task_manager=task_manager,

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -3,6 +3,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from args import CLIArgs
 from providers import BeaconChain, Keymanager, MultiBeaconNode, SignatureProvider
+from providers.duty_cache import DutyCacheProvider
 from services import (
     AttestationService,
     BlockProposalService,
@@ -19,6 +20,7 @@ def validator_duty_service_options(
     beacon_chain: BeaconChain,
     signature_provider: SignatureProvider,
     keymanager: Keymanager,
+    duty_cache_provider: DutyCacheProvider,
     validator_status_tracker: ValidatorStatusTrackerService,
     scheduler: AsyncIOScheduler,
     task_manager: TaskManager,
@@ -29,6 +31,7 @@ def validator_duty_service_options(
         beacon_chain=beacon_chain,
         signature_provider=signature_provider,
         keymanager=keymanager,
+        duty_cache_provider=duty_cache_provider,
         validator_status_tracker_service=validator_status_tracker,
         scheduler=scheduler,
         task_manager=task_manager,


### PR DESCRIPTION
This PR makes missing attestations during VC restarts even less likely by caching validator duties on-disk (incl. proofs for attestation aggregation duties).