### PR TITLE
Default to values set via CLI in the Keymanager API

### DIFF
--- a/src/api/keymanager/api.py
+++ b/src/api/keymanager/api.py
@@ -36,7 +36,7 @@ def _get_bearer_token_value(cli_args: CLIArgs) -> str:
 
 
 def _create_app(keymanager: "Keymanager", cli_args: CLIArgs) -> web.Application:
-    app = web.Application(middlewares=[bearer_authentication, exception_handler])
+    app = web.Application(middlewares=[exception_handler, bearer_authentication])
 
     app["bearer_token"] = _get_bearer_token_value(cli_args=cli_args)
     app["keymanager"] = keymanager

--- a/src/api/keymanager/fee_recipient_endpoints.py
+++ b/src/api/keymanager/fee_recipient_endpoints.py
@@ -35,6 +35,11 @@ async def fee_recipient_post(request: web.Request) -> web.Response:
         type=SchemaKeymanagerAPI.SetFeeRecipientRequest,
     )
 
+    if request_data.ethaddress == "0x0000000000000000000000000000000000000000":
+        raise web.HTTPBadRequest(
+            reason="Cannot specify the 0x00 fee recipient address through the API."
+        )
+
     pubkey = request.match_info["pubkey"]
     keymanager: Keymanager = request.app["keymanager"]
 

--- a/src/schemas/keymanager_api.py
+++ b/src/schemas/keymanager_api.py
@@ -67,7 +67,7 @@ class DeleteRemoteKeysResponse(msgspec.Struct):
 # Fee recipient endpoints
 class ValidatorFeeRecipient(msgspec.Struct):
     pubkey: Pubkey
-    ethaddress: EthAddress | None
+    ethaddress: EthAddress
 
 
 class ListFeeRecipientResponse(msgspec.Struct):
@@ -81,7 +81,7 @@ class SetFeeRecipientRequest(msgspec.Struct):
 # Gas limit endpoints
 class ValidatorGasLimit(msgspec.Struct):
     pubkey: Pubkey
-    gas_limit: UInt64String | None
+    gas_limit: UInt64String
 
 
 class ListGasLimitResponse(msgspec.Struct):
@@ -95,7 +95,7 @@ class SetGasLimitRequest(msgspec.Struct):
 # Graffiti endpoints
 class ValidatorGraffiti(msgspec.Struct):
     pubkey: Pubkey
-    graffiti: str | None
+    graffiti: str
 
 
 class GraffitiResponse(msgspec.Struct):

--- a/src/spec/utils.py
+++ b/src/spec/utils.py
@@ -8,3 +8,7 @@ def encode_graffiti(graffiti_string: str) -> bytes:
         )
 
     return encoded
+
+
+def decode_graffiti(graffiti_bytes: bytes) -> str:
+    return graffiti_bytes.rstrip(b"\x00").decode("utf-8")

--- a/tests/api/keymanager/test_gas_limit_endpoints.py
+++ b/tests/api/keymanager/test_gas_limit_endpoints.py
@@ -32,7 +32,9 @@ async def test_gas_limit_lifecycle(
         await resp.text(), type=SchemaKeymanagerAPI.ListGasLimitResponse
     )
     assert response.data.pubkey == pubkey
-    assert response.data.gas_limit is None
+    # We return the default gas limit value provided via CLI arguments if
+    # it was not overridden via the Keymanager API
+    assert response.data.gas_limit == "30000000"
     assert keymanager.pubkey_to_gas_limit_override.get(pubkey) is None
 
     # Set its gas limit value
@@ -68,7 +70,9 @@ async def test_gas_limit_lifecycle(
         await resp.text(), type=SchemaKeymanagerAPI.ListGasLimitResponse
     )
     assert response.data.pubkey == pubkey
-    assert response.data.gas_limit is None
+    # We return the default gas limit value provided via CLI arguments if
+    # it was not overridden via the Keymanager API
+    assert response.data.gas_limit == "30000000"
     assert keymanager.pubkey_to_gas_limit_override.get(pubkey) is None
 
 

--- a/tests/api/keymanager/test_graffiti_endpoints.py
+++ b/tests/api/keymanager/test_graffiti_endpoints.py
@@ -32,7 +32,9 @@ async def test_graffiti_lifecycle(
         await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
     )
     assert response.data.pubkey == pubkey
-    assert response.data.graffiti is None
+    # We return the default graffiti value provided via CLI arguments if
+    # it was not overridden via the Keymanager API
+    assert response.data.graffiti == "graffiti-in-pytest"
     assert keymanager.pubkey_to_graffiti_override.get(pubkey) is None
 
     # Set its graffiti
@@ -68,7 +70,9 @@ async def test_graffiti_lifecycle(
         await resp.text(), type=SchemaKeymanagerAPI.GraffitiResponse
     )
     assert response.data.pubkey == pubkey
-    assert response.data.graffiti is None
+    # We return the default graffiti value provided via CLI arguments if
+    # it was not overridden via the Keymanager API
+    assert response.data.graffiti == "graffiti-in-pytest"
     assert keymanager.pubkey_to_graffiti_override.get(pubkey) is None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,9 @@ def cli_args(
         attestation_consensus_threshold=_process_attestation_consensus_threshold(
             None, [beacon_node_url]
         ),
-        fee_recipient="0x0000000000000000000000000000000000000000",
+        fee_recipient="0xfee0000000000000000000000000000000000000",
         data_dir=str(tmp_path),
-        graffiti=b"pytest",
+        graffiti=b"graffiti-in-pytest",
         gas_limit=30_000_000,
         use_external_builder=False,
         builder_boost_factor=90,


### PR DESCRIPTION
As reported on the ethstaker Discord, Vero should return the default fee recipient value for a pubkey on the Keymanager API if that pubkey's fee recipient value has not been overridden.

This is also mentioned in the Keymanager API spec:

> The validator public key will return with the default fee recipient address if a specific one was not found.

Similarly for the values for gas limit and graffiti.

There's one more edge case that I overlooked in the initial implementation – apparently it should not be possible to set the fee recipient to the zero address via the Keymanager API:

> Cannot specify the 0x00 fee recipient address through the API.