### PR TITLE
Store debug logs in datadir

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -32,7 +32,7 @@ class CLIArgs(msgspec.Struct, kw_only=True):
     metrics_address: str
     metrics_port: int
     metrics_multiprocess_mode: bool
-    log_level: str
+    log_level: int
     disable_slashing_detection: bool
 
 
@@ -120,6 +120,8 @@ def log_cli_arg_values(validated_args: CLIArgs) -> None:
             validated_arg_value = ",".join(validated_arg_value)
         elif action.dest == "graffiti":
             validated_arg_value = decode_graffiti(validated_arg_value)
+        elif action.dest == "log_level":
+            validated_arg_value = logging.getLevelName(validated_arg_value)
 
         if action.default != validated_arg_value:
             logger.info(f"{action.dest}: {validated_arg_value}")
@@ -342,7 +344,7 @@ def parse_cli_args(args: Sequence[str]) -> CLIArgs:
             metrics_address=parsed_args.metrics_address,
             metrics_port=parsed_args.metrics_port,
             metrics_multiprocess_mode=parsed_args.metrics_multiprocess_mode,
-            log_level=parsed_args.log_level,
+            log_level=logging.getLevelName(parsed_args.log_level),
             disable_slashing_detection=parsed_args.DANGER____disable_slashing_detection,
         )
     except ValueError as e:

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,6 @@ async def main(cli_args: CLIArgs, shutdown_event: asyncio.Event) -> None:
     logging.getLogger("vero-init").info(
         f"Starting vero {get_service_version()} (commit {get_service_commit()})",
     )
-    check_data_dir_permissions(data_dir=Path(cli_args.data_dir))
 
     scheduler = AsyncIOScheduler(
         timezone=datetime.UTC,
@@ -65,11 +64,13 @@ async def main(cli_args: CLIArgs, shutdown_event: asyncio.Event) -> None:
 
 if __name__ == "__main__":
     cli_args = parse_cli_args(args=sys.argv[1:])
+    check_data_dir_permissions(data_dir=Path(cli_args.data_dir))
     init_observability(
         metrics_address=cli_args.metrics_address,
         metrics_port=cli_args.metrics_port,
         metrics_multiprocess_mode=cli_args.metrics_multiprocess_mode,
         log_level=cli_args.log_level,
+        data_dir=Path(cli_args.data_dir),
     )
     log_cli_arg_values(cli_args)
     asyncio.run(main(cli_args=cli_args, shutdown_event=asyncio.Event()))

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ._logging import setup_logging
 from ._metrics import setup_metrics
 from ._metrics_shared import ErrorType, get_shared_metrics
@@ -10,9 +12,13 @@ def init_observability(
     metrics_address: str,
     metrics_port: int,
     metrics_multiprocess_mode: bool,
-    log_level: str,
+    log_level: int,
+    data_dir: Path,
 ) -> None:
-    setup_logging(log_level=log_level)
+    setup_logging(
+        log_level=log_level,
+        data_dir=data_dir,
+    )
     setup_metrics(
         addr=metrics_address,
         port=metrics_port,

--- a/src/observability/_logging.py
+++ b/src/observability/_logging.py
@@ -1,7 +1,17 @@
 import logging
+from logging.handlers import QueueHandler, QueueListener
+from pathlib import Path
+from queue import Queue
 
 
-def setup_logging(log_level: str) -> None:
+def setup_logging(
+    log_level: int,
+    data_dir: Path,
+) -> None:
+    """
+    Configure logging to use stdout and a rotating debug log file.
+    Uses a background thread to handle logging without blocking the asyncio event loop.
+    """
     logging.logProcesses = False
     logging.logThreads = False
     logging.logMultiprocessing = False
@@ -9,14 +19,35 @@ def setup_logging(log_level: str) -> None:
         logging.logAsyncioTasks = False
 
     root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
     root_logger.handlers.clear()
     formatter = logging.Formatter(
         "%(asctime)s - %(name)-20s - %(levelname)-5s: %(message)s",
     )
+
+    # StreamHandler - logs to stdout
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
-    root_logger.addHandler(stream_handler)
-    root_logger.setLevel(log_level)
-    if log_level != logging.getLevelName(logging.DEBUG):
+    stream_handler.setLevel(log_level)
+
+    # FileHandler - logs to a rotating log file at debug level
+    #  This allows us to inspect debug level logs in case of issues
+    debug_file_handler = logging.handlers.RotatingFileHandler(
+        data_dir / "debug.log",
+        maxBytes=5_000_000,
+        backupCount=4,
+    )
+    debug_file_handler.setFormatter(formatter)
+    debug_file_handler.setLevel(logging.DEBUG)
+
+    # Use QueueHandler and QueueListener to process logs off of the main thread
+    queue: Queue[logging.LogRecord] = Queue()
+    root_logger.addHandler(QueueHandler(queue))
+    listener = QueueListener(
+        queue, stream_handler, debug_file_handler, respect_handler_level=True
+    )
+    listener.start()
+
+    if log_level != logging.DEBUG:
         # apscheduler is quite verbose with default INFO logging
         logging.getLogger("apscheduler").setLevel(logging.WARNING)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import random
 import time
 from asyncio import AbstractEventLoop
@@ -82,7 +83,7 @@ def cli_args(
         metrics_address="localhost",
         metrics_port=8000,
         metrics_multiprocess_mode=False,
-        log_level="INFO",
+        log_level=logging.INFO,
         disable_slashing_detection=False,
     )
 
@@ -93,7 +94,8 @@ def _init_observability() -> None:
         metrics_address="localhost",
         metrics_port=8080,
         metrics_multiprocess_mode=False,
-        log_level="DEBUG",
+        log_level=logging.DEBUG,
+        data_dir=Path("/tmp"),
     )
 
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -401,6 +402,23 @@ from spec.configs import Network
             ],
             id="--enable-keymanager-api (no --remote-signer-url)",
         ),
+        pytest.param(
+            [
+                "--network=mainnet",
+                "--remote-signer-url=http://signer:9000",
+                "--beacon-node-urls=http://beacon-node:5052",
+                "--fee-recipient=0x1c6c96549debfc6aaec7631051b84ce9a6e11ad2",
+                "--log-level=DEBUG",
+            ],
+            None,
+            {
+                "log_level": logging.DEBUG,
+            },
+            [
+                "log_level: DEBUG",
+            ],
+            id="--log-level override",
+        ),
     ],
 )
 def test_parse_cli_args(
@@ -468,7 +486,7 @@ def test_parse_cli_args_full_set() -> None:
         "metrics_address": "1.2.3.4",
         "metrics_port": 4321,
         "metrics_multiprocess_mode": True,
-        "log_level": "DEBUG",
+        "log_level": logging.DEBUG,
         "disable_slashing_detection": True,
     }
 
@@ -526,7 +544,7 @@ def test_parse_cli_args_minimal_set_with_defaults() -> None:
         metrics_address="localhost",
         metrics_port=8000,
         metrics_multiprocess_mode=False,
-        log_level="INFO",
+        log_level=logging.INFO,
         disable_slashing_detection=False,
     )
 


### PR DESCRIPTION
Resolves #146 

Stores up to 25MB worth of debug logs in Vero's data directory to aid with investigating issues.

The logging logic has been changed to be completely non-blocking, happening in a background thread using `QueueHandler` and `QueueListener`.