### PR TITLE
Adjust log level for dependent root mismatch in AttestationService

### DIFF
--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -108,7 +108,7 @@ class AttestationService(ValidatorDutyService):
             )
             and len(self.attester_duties_dependent_roots) > 0
         ):
-            self.logger.info(
+            self.logger.debug(
                 "Head event duty dependent root mismatch -> updating duties",
             )
             self.task_manager.submit_task(super().update_duties())


### PR DESCRIPTION
With the change from #147 it takes longer to update the `attester_duties_dependent_roots` dictionary in the `AttestationService`, resulting in some unnecessary frequent INFO-level messages in the logs, especially during the first slot of an epoch:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/93d0859e-83ae-4645-92cf-d4481d44585a" />

We could adjust the duty processing logic but that would just add complexity. Instead the log level for this kind of message was reduced to DEBUG.