### PR TITLE
Pin all used GitHub actions to specific commit

### DIFF
--- a/.github/workflows/assertoor.yml
+++ b/.github/workflows/assertoor.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build Docker image
         run: docker build -t vero:custom .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Docker metadata
       id: docker_metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: ghcr.io/${{ github.repository_owner }}/vero
         tags: |
@@ -39,14 +39,14 @@ jobs:
           type=semver,pattern={{version}},prefix=v
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         build-args: |
           GIT_TAG=${{ github.ref_name }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,15 +17,15 @@ jobs:
       PRE_COMMIT_HOME: ${{ github.workspace }}/.pre-commit
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         activate-environment: true
 
     - name: Cache pre-commit
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ env.PRE_COMMIT_HOME }}
         key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       with:
         activate-environment: true
     - name: Run pytest

--- a/.github/workflows/verify-configs.yml
+++ b/.github/workflows/verify-configs.yml
@@ -13,7 +13,7 @@ jobs:
   verify-configs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Compare config files
         run: |


### PR DESCRIPTION
Previously, some of the more trusted GitHub actions (e.g. official ones like `actions/checkout` and actions provided by docker/astral) were only loosely pinned to a tag.

With this PR, all actions reference a specific commit, hardening the security of the repository workflows.