### PR TITLE
Temporarily hardcode aiosignal version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         additional_dependencies:
           [
           aiohttp==3.12.11,
+          aiosignal==1.3.2,
           msgspec==0.19.0,
           prometheus-client==0.22.0,
           pytest==8.3.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.11.13",
+    "aiosignal==1.3.2",
     "apscheduler>=3.11.0",
     "msgspec>=0.19.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.31.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,7 +50,9 @@ aioresponses==0.7.8 \
 aiosignal==1.3.2 \
     --hash=sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5 \
     --hash=sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   vero
 apscheduler==3.11.0 \
     --hash=sha256:4c622d250b0955a65d5d0eb91c33e6d43fd879834bf541e0a18661ae60460133 \
     --hash=sha256:fc134ca32e50f5eadcc4938e3a4545ab19131435e851abb40b34d63d5141c6da

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,9 @@ aiohttp==3.12.11 \
 aiosignal==1.3.2 \
     --hash=sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5 \
     --hash=sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   vero
 apscheduler==3.11.0 \
     --hash=sha256:4c622d250b0955a65d5d0eb91c33e6d43fd879834bf541e0a18661ae60460133 \
     --hash=sha256:fc134ca32e50f5eadcc4938e3a4545ab19131435e851abb40b34d63d5141c6da

--- a/uv.lock
+++ b/uv.lock
@@ -847,6 +847,7 @@ version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosignal" },
     { name = "apscheduler" },
     { name = "msgspec" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -871,6 +872,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.13" },
+    { name = "aiosignal", specifier = "==1.3.2" },
     { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.31.0" },


### PR DESCRIPTION
The new version of aiosignal causes mypy to fail (e.g. https://github.com/serenita-org/vero/actions/runs/16114769704/job/45466067442). We'll need to wait for a new aiohttp version to be released before it can be fixed properly.