### PR TITLE
Fix log level handling for stdout handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ asyncio_default_fixture_loop_scope = "function"
 [tool.ruff.lint]
 # Enable all rules and explicitly disable some that we don't comply with (yet?)
 select = ["ALL"]
-ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM812", "ERA001", "E501", "FBT", "G004", "ISC001", "N805", "N812", "N818", "TRY003", "TRY400", "BLE001"]
+ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM812", "ERA001", "E501", "FBT", "G004", "ISC001", "N805", "N812", "N818", "TRY003", "TRY400", "TRY401", "BLE001"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/mock_api/beacon_node.py" = ["C901"]

--- a/src/api/keymanager/api.py
+++ b/src/api/keymanager/api.py
@@ -76,8 +76,7 @@ async def start_server(keymanager: "Keymanager", cli_args: CLIArgs) -> None:
         await app.cleanup()
 
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"Unexpected error occurred - exiting... {e!r}",
-            exc_info=logger.isEnabledFor(logging.DEBUG),
         )
         sys.exit(1)

--- a/src/api/keymanager/middlewares.py
+++ b/src/api/keymanager/middlewares.py
@@ -49,9 +49,8 @@ async def exception_handler(
         status_code = 500
         msg = repr(e)
         logger = logging.getLogger("api.keymanager.middlewares.exception_handler")
-        logger.error(
+        logger.exception(
             f"Exception occurred while handling request to {request.url}: {msg}",
-            exc_info=logger.isEnabledFor(logging.DEBUG),
         )
 
     return web.json_response(

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -199,9 +199,8 @@ class BeaconNode:
                 f"Initialized beacon node at {self.base_url}",
             )
         except Exception as e:
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to initialize beacon node at {self.base_url}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             # Try to initialize again in 30 seconds
             self.task_manager.submit_task(self.initialize_full(), delay=30.0)
@@ -269,9 +268,8 @@ class BeaconNode:
         except BeaconNodeUnsupportedEndpoint:
             raise
         except Exception as e:
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to get response from {self.host} for {method} {endpoint}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             self.score -= BeaconNode.SCORE_DELTA_FAILURE
             raise
@@ -387,9 +385,8 @@ class BeaconNode:
                     if att_data.beacon_block_root.to_obj() == expected_head_block_root:
                         return self.host, att_data
                 except Exception as e:
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to produce attestation data: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
 
                 # Rate-limiting - wait at least 50ms in between requests
@@ -741,14 +738,6 @@ class BeaconNode:
         fork_version: SchemaBeaconAPI.ForkVersion,
         signed_beacon_block_contents: "SpecBeaconBlock.ElectraBlockContentsSigned",
     ) -> None:
-        if self.logger.isEnabledFor(logging.DEBUG):
-            block = signed_beacon_block_contents.signed_block.message
-            self.logger.debug(
-                f"Publishing block for slot {block.slot},"
-                f" block root {block.hash_tree_root().hex()},"
-                f" body root {block.body.hash_tree_root().hex()}",
-            )
-
         with self.tracer.start_as_current_span(
             name=f"{self.__class__.__name__}.publish_block_v2",
             kind=SpanKind.CLIENT,
@@ -771,14 +760,6 @@ class BeaconNode:
         fork_version: SchemaBeaconAPI.ForkVersion,
         signed_blinded_beacon_block: "SpecBeaconBlock.ElectraBlindedBlockSigned",
     ) -> None:
-        if self.logger.isEnabledFor(logging.DEBUG):
-            block = signed_blinded_beacon_block.message
-            self.logger.debug(
-                f"Publishing blinded block for slot {block.slot},"
-                f" block root {block.hash_tree_root().hex()},"
-                f" body root {block.body.hash_tree_root().hex()}",
-            )
-
         with self.tracer.start_as_current_span(
             name=f"{self.__class__.__name__}.publish_blinded_block_v2",
             kind=SpanKind.CLIENT,
@@ -843,9 +824,8 @@ class BeaconNode:
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.EVENT_CONSUMER.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to parse event name from {decoded} ({e!r}) -> ignoring event...",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     continue
 

--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -510,9 +510,8 @@ class MultiBeaconNode:
                 # Deadline reached
                 continue
             except Exception as e:
-                self.logger.error(
+                self.logger.exception(
                     f"Failed waiting for attestation data: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 continue
 
@@ -552,9 +551,8 @@ class MultiBeaconNode:
                     host, att_data = await coro
                 except Exception as e:
                     # We can tolerate some attestation data production failures
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to produce attestation data: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     continue
 
@@ -734,9 +732,8 @@ class MultiBeaconNode:
                 _ERRORS_METRIC.labels(
                     error_type=ErrorType.AGGREGATE_ATTESTATION_PRODUCE.value,
                 ).inc()
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to produce aggregate attestation for slot {attestation_data.slot}: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
 
     async def publish_aggregate_and_proofs(

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import datetime
-import logging
 from collections import defaultdict
 from types import TracebackType
 from typing import Self, Unpack
@@ -231,9 +230,8 @@ class AttestationService(ValidatorDutyService):
                         committee_index=0,
                     )
                 except AttestationConsensusFailure as e:
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to produce attestation data: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     _VC_ATTESTATION_CONSENSUS_FAILURES.inc()
                     _ERRORS_METRIC.labels(
@@ -298,9 +296,8 @@ class AttestationService(ValidatorDutyService):
                         _ERRORS_METRIC.labels(
                             error_type=ErrorType.SIGNATURE.value,
                         ).inc()
-                        self.logger.error(
+                        self.logger.exception(
                             f"Failed to get signature for attestation for slot {slot}: {e!r}",
-                            exc_info=self.logger.isEnabledFor(logging.DEBUG),
                         )
                         sign_span.set_status(Status(StatusCode.ERROR))
                         sign_span.record_exception(e)
@@ -350,9 +347,8 @@ class AttestationService(ValidatorDutyService):
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.ATTESTATION_PUBLISH.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to publish attestations for slot {att_data.slot}: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     publish_span.set_status(Status(StatusCode.ERROR))
                     publish_span.record_exception(e)
@@ -432,9 +428,8 @@ class AttestationService(ValidatorDutyService):
             _ERRORS_METRIC.labels(
                 error_type=ErrorType.AGGREGATE_ATTESTATION_PUBLISH.value,
             ).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to publish aggregate and proofs for slot {slot}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
 
     async def aggregate_attestations(
@@ -534,9 +529,8 @@ class AttestationService(ValidatorDutyService):
             )
         except Exception as e:
             _ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to get signatures for aggregation selection proofs: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             raise
 

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import time
 from collections import defaultdict
 from types import TracebackType
@@ -272,9 +271,8 @@ class BlockProposalService(ValidatorDutyService):
                 )
             except Exception as e:
                 _ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to get signature for validator registrations: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 continue
 
@@ -361,9 +359,8 @@ class BlockProposalService(ValidatorDutyService):
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.SIGNATURE.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to get signature for RANDAO reveal: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     self._last_slot_duty_completed_for = slot
                     raise
@@ -396,9 +393,8 @@ class BlockProposalService(ValidatorDutyService):
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.BLOCK_PRODUCE.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to produce block: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     self._last_slot_duty_completed_for = slot
                     raise
@@ -436,9 +432,8 @@ class BlockProposalService(ValidatorDutyService):
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.SIGNATURE.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to get signature for block: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     self._last_slot_duty_completed_for = slot
                     raise
@@ -494,9 +489,8 @@ class BlockProposalService(ValidatorDutyService):
                     _ERRORS_METRIC.labels(
                         error_type=ErrorType.BLOCK_PUBLISH.value,
                     ).inc()
-                    self.logger.error(
+                    self.logger.exception(
                         f"Failed to publish block for slot {slot}: {e!r}",
-                        exc_info=self.logger.isEnabledFor(logging.DEBUG),
                     )
                     raise
                 else:

--- a/src/services/event_consumer.py
+++ b/src/services/event_consumer.py
@@ -115,8 +115,7 @@ class EventConsumerService:
             _ERRORS_METRIC.labels(
                 error_type=ErrorType.EVENT_CONSUMER.value,
             ).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Error occurred while processing beacon node events from {beacon_node.host} ({e!r}). Reconnecting in 1 second...",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             self.task_manager.submit_task(self.handle_events(), delay=1.0)

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import datetime
-import logging
 from collections import defaultdict
 from types import TracebackType
 from typing import Self, Unpack
@@ -172,9 +171,8 @@ class SyncCommitteeService(ValidatorDutyService):
                     block_id="head",
                 )
             except Exception as e:
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to get beacon block root: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 _ERRORS_METRIC.labels(
                     error_type=ErrorType.SYNC_COMMITTEE_MESSAGE_PRODUCE.value,
@@ -202,9 +200,8 @@ class SyncCommitteeService(ValidatorDutyService):
                 msg, sig, pubkey = await coro
             except Exception as e:
                 _ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to get signature for sync committee message for slot {duty_slot}: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 continue
 
@@ -247,9 +244,8 @@ class SyncCommitteeService(ValidatorDutyService):
             _ERRORS_METRIC.labels(
                 error_type=ErrorType.SYNC_COMMITTEE_MESSAGE_PUBLISH.value,
             ).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to publish sync committee messages for slot {duty_slot}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
         else:
             self.logger.info(
@@ -294,9 +290,8 @@ class SyncCommitteeService(ValidatorDutyService):
             selection_proofs = await asyncio.gather(*selection_proofs_coroutines)
         except Exception as e:
             _ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to get signatures for sync selection proofs for slot {duty_slot}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             return
 
@@ -374,9 +369,8 @@ class SyncCommitteeService(ValidatorDutyService):
             _ERRORS_METRIC.labels(
                 error_type=ErrorType.SYNC_COMMITTEE_CONTRIBUTION_PUBLISH.value,
             ).inc()
-            self.logger.error(
+            self.logger.exception(
                 f"Failed to publish sync committee contribution and proofs for slot {duty_slot}: {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
 
     async def aggregate_sync_messages(

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -189,9 +189,8 @@ class ValidatorDutyService:
                 break
             except Exception as e:
                 _ERRORS_METRIC.labels(error_type=ErrorType.DUTIES_UPDATE.value).inc()
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to update duties: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
 
                 # Wait for the current delay before retrying again

--- a/src/services/validator_status_tracker.py
+++ b/src/services/validator_status_tracker.py
@@ -204,9 +204,8 @@ class ValidatorStatusTrackerService:
                 _ERRORS_METRIC.labels(
                     error_type=ErrorType.VALIDATOR_STATUS_UPDATE.value
                 ).inc()
-                self.logger.error(
+                self.logger.exception(
                     f"Failed to update validator statuses: {e!r}",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
 
                 # Wait for the current delay before retrying again

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -24,9 +24,8 @@ class TaskManager:
             # Re-raise the exception to get a nice traceback
             task.result()
         except Exception as e:
-            self.logger.error(
+            self.logger.exception(
                 f"Task {task} failed with exception {e!r}",
-                exc_info=self.logger.isEnabledFor(logging.DEBUG),
             )
             _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
 
@@ -36,9 +35,8 @@ class TaskManager:
         except asyncio.CancelledError:
             if not self.shutdown_event.is_set():
                 # Log cancellations as errors only if we're not shutting down
-                self.logger.error(
+                self.logger.exception(
                     f"Task {task} was cancelled",
-                    exc_info=self.logger.isEnabledFor(logging.DEBUG),
                 )
                 _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
         else:


### PR DESCRIPTION
The changes from #146 affect the way we log exceptions. The `logger.isEnabledFor(logging.DEBUG)` statement that was previously used is no longer relevant since the logger is always enabled at the debug level.

Therefore to differentiate the exception logging (always log full exception to debug log, only log full exception to stdout if log level set to DEBUG) we need to do things differently.

The `QueueHandler` pre-processes log records before sending them to the `QueueListener` (mainly to avoid pickling issues), therefore formatting happens on the main thread and (!) results in an identically formatted message for all `QueueListener`-attached handlers. For that reason we cannot use the stdout `StreamHandler` as part of the `QueueListener` - it is too late to change the record format (suppressing the full exception) once the message is retrieved from the queue.

Therefore we will handle the stdout `StreamHandler` messages on the main thread (as it was done before #146) and only handle the debug `FileHandler` messages through the `QueueListener` in a separate thread.