### PR TITLE
Fix serialization of `DepositRequest.index`

### DIFF
--- a/src/spec/block.py
+++ b/src/spec/block.py
@@ -1,4 +1,4 @@
-from remerkleable.basic import uint64, uint256
+from remerkleable.basic import uint256
 from remerkleable.bitfields import Bitvector
 from remerkleable.byte_arrays import ByteList, Bytes32, Bytes48, ByteVector
 from remerkleable.complex import Container, List, Vector
@@ -115,7 +115,7 @@ class DepositRequest(Container):
     withdrawal_credentials: Bytes32
     amount: Gwei
     signature: BLSSignature
-    index: uint64
+    index: UInt64SerializedAsString
 
 
 class WithdrawalRequest(Container):


### PR DESCRIPTION
When publishing blocks, Vero was incorrectly serializing the value of the `DepositRequest.index` as an int instead of a string as required by the spec.

This issue was not discovered earlier for a combination of reasons:
- some CL clients accept the non-spec-compliant integer values (Lighthouse, Lodestar, Teku) while others do not (Prysm/Nimbus).
- the Kurtosis tests that are run against the different client combinations include EL transactions, blobs, ... but no deposit requests.

A follow-up PR will be created with measures to reduce the chances of this kind of serialization error happening again. (Edit: see #168)