### PR TITLE
Enforce use of `SerializedAsString` uint types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,10 @@ repos:
       - id: uv-export
         name: export dev dependencies -> requirements-dev.txt
         args: ["--dev", "--output-file=requirements-dev.txt"]
+
+  - repo: local
+    hooks:
+      - id: check-spec-types
+        name: check types used in spec
+        entry: ./src/spec/type_check.sh
+        language: system

--- a/src/spec/base.py
+++ b/src/spec/base.py
@@ -1,12 +1,11 @@
 import copy
 from typing import Self
 
-from remerkleable.basic import uint64
 from remerkleable.byte_arrays import Bytes4
 from remerkleable.complex import Container
 from remerkleable.core import ObjParseException, ObjType
 
-from spec.common import Root
+from spec.common import Root, UInt64SerializedAsString
 
 
 class Version(Bytes4):
@@ -16,63 +15,63 @@ class Version(Bytes4):
 class Fork(Container):
     previous_version: Version
     current_version: Version
-    epoch: uint64
+    epoch: UInt64SerializedAsString
 
 
 class Genesis(Container):
-    genesis_time: uint64
+    genesis_time: UInt64SerializedAsString
     genesis_validators_root: Root
     genesis_fork_version: Version
 
 
 class SpecElectra(Container):
     # Phase 0
-    SECONDS_PER_SLOT: uint64
-    SLOTS_PER_EPOCH: uint64
-    MAX_VALIDATORS_PER_COMMITTEE: uint64
-    MAX_COMMITTEES_PER_SLOT: uint64
+    SECONDS_PER_SLOT: UInt64SerializedAsString
+    SLOTS_PER_EPOCH: UInt64SerializedAsString
+    MAX_VALIDATORS_PER_COMMITTEE: UInt64SerializedAsString
+    MAX_COMMITTEES_PER_SLOT: UInt64SerializedAsString
     GENESIS_FORK_VERSION: Version
-    MAX_PROPOSER_SLASHINGS: uint64
-    MAX_ATTESTER_SLASHINGS: uint64
-    MAX_ATTESTATIONS: uint64
-    MAX_DEPOSITS: uint64
-    MAX_VOLUNTARY_EXITS: uint64
+    MAX_PROPOSER_SLASHINGS: UInt64SerializedAsString
+    MAX_ATTESTER_SLASHINGS: UInt64SerializedAsString
+    MAX_ATTESTATIONS: UInt64SerializedAsString
+    MAX_DEPOSITS: UInt64SerializedAsString
+    MAX_VOLUNTARY_EXITS: UInt64SerializedAsString
 
     # Altair
-    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: uint64
-    SYNC_COMMITTEE_SIZE: uint64
-    ALTAIR_FORK_EPOCH: uint64
+    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: UInt64SerializedAsString
+    SYNC_COMMITTEE_SIZE: UInt64SerializedAsString
+    ALTAIR_FORK_EPOCH: UInt64SerializedAsString
     ALTAIR_FORK_VERSION: Version
 
     # Bellatrix
-    BELLATRIX_FORK_EPOCH: uint64
+    BELLATRIX_FORK_EPOCH: UInt64SerializedAsString
     BELLATRIX_FORK_VERSION: Version
 
-    BYTES_PER_LOGS_BLOOM: uint64
-    MAX_EXTRA_DATA_BYTES: uint64
-    MAX_TRANSACTIONS_PER_PAYLOAD: uint64
-    MAX_BYTES_PER_TRANSACTION: uint64
+    BYTES_PER_LOGS_BLOOM: UInt64SerializedAsString
+    MAX_EXTRA_DATA_BYTES: UInt64SerializedAsString
+    MAX_TRANSACTIONS_PER_PAYLOAD: UInt64SerializedAsString
+    MAX_BYTES_PER_TRANSACTION: UInt64SerializedAsString
 
     # Capella
-    MAX_WITHDRAWALS_PER_PAYLOAD: uint64
-    CAPELLA_FORK_EPOCH: uint64
+    MAX_WITHDRAWALS_PER_PAYLOAD: UInt64SerializedAsString
+    CAPELLA_FORK_EPOCH: UInt64SerializedAsString
     CAPELLA_FORK_VERSION: Version
-    MAX_BLS_TO_EXECUTION_CHANGES: uint64
+    MAX_BLS_TO_EXECUTION_CHANGES: UInt64SerializedAsString
 
     # Deneb
-    MAX_BLOB_COMMITMENTS_PER_BLOCK: uint64
-    DENEB_FORK_EPOCH: uint64
+    MAX_BLOB_COMMITMENTS_PER_BLOCK: UInt64SerializedAsString
+    DENEB_FORK_EPOCH: UInt64SerializedAsString
     DENEB_FORK_VERSION: Version
-    FIELD_ELEMENTS_PER_BLOB: uint64
+    FIELD_ELEMENTS_PER_BLOB: UInt64SerializedAsString
 
     # Electra
-    ELECTRA_FORK_EPOCH: uint64
+    ELECTRA_FORK_EPOCH: UInt64SerializedAsString
     ELECTRA_FORK_VERSION: Version
-    MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: uint64
-    MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: uint64
-    MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: uint64
-    MAX_ATTESTATIONS_ELECTRA: uint64
-    MAX_ATTESTER_SLASHINGS_ELECTRA: uint64
+    MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: UInt64SerializedAsString
+    MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: UInt64SerializedAsString
+    MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: UInt64SerializedAsString
+    MAX_ATTESTATIONS_ELECTRA: UInt64SerializedAsString
+    MAX_ATTESTER_SLASHINGS_ELECTRA: UInt64SerializedAsString
 
     @classmethod
     def from_obj(cls, obj: ObjType) -> Self:

--- a/src/spec/block.py
+++ b/src/spec/block.py
@@ -1,8 +1,6 @@
-from remerkleable.basic import uint256
 from remerkleable.bitfields import Bitvector
 from remerkleable.byte_arrays import ByteList, Bytes32, Bytes48, ByteVector
 from remerkleable.complex import Container, List, Vector
-from remerkleable.core import ObjType
 
 from spec.attestation import (
     AttestationData,
@@ -17,6 +15,7 @@ from spec.common import (
     Root,
     Slot,
     UInt64SerializedAsString,
+    UInt256SerializedAsString,
     ValidatorIndex,
 )
 from spec.constants import BYTES_PER_FIELD_ELEMENT, DEPOSIT_CONTRACT_TREE_DEPTH
@@ -103,11 +102,6 @@ class SignedBLSToExecutionChange(Container):
 
 class KZGCommitment(Bytes48):
     pass
-
-
-class UInt256SerializedAsString(uint256):
-    def to_obj(self) -> ObjType:
-        return str(self)
 
 
 class DepositRequest(Container):

--- a/src/spec/common.py
+++ b/src/spec/common.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 from typing import Literal
 
-from remerkleable.basic import uint64
+from remerkleable.basic import uint64, uint256
 from remerkleable.byte_arrays import Bytes32, Bytes48, Bytes96
 from remerkleable.core import ObjType
 
@@ -23,6 +23,11 @@ class BLSSignature(Bytes96):
 
 
 class UInt64SerializedAsString(uint64):
+    def to_obj(self) -> ObjType:
+        return str(self)
+
+
+class UInt256SerializedAsString(uint256):
     def to_obj(self) -> ObjType:
         return str(self)
 

--- a/src/spec/type_check.sh
+++ b/src/spec/type_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+violations=$(grep -r --include="*.py" ": uint" ./src/spec)
+
+if [[ -n "$violations" ]]; then
+  echo "ERROR: Found use of 'uint' type. Use the 'SerializedAsString' variant instead."
+  echo "$violations"
+  exit 1
+fi

--- a/tests/providers/test_beacon_node.py
+++ b/tests/providers/test_beacon_node.py
@@ -8,6 +8,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from providers import BeaconNode
 from spec.base import SpecElectra, Version
+from spec.common import UInt64SerializedAsString
 from tasks import TaskManager
 
 
@@ -32,7 +33,7 @@ async def test_initialize_spec_mismatch(
         spec_to_return = spec
         if spec_mismatch:
             spec_to_return = copy(spec)
-            spec_to_return.SLOTS_PER_EPOCH = 5
+            spec_to_return.SLOTS_PER_EPOCH = UInt64SerializedAsString(5)
             spec_to_return.ELECTRA_FORK_VERSION = Version("0x00abcdef")
 
         m.get(


### PR DESCRIPTION
To prevent another issue like #167 from happening in the future, a new pre-commit hook is added that checks that `SerializedAsString` variants of the `uint` type are used.