### PR TITLE
Make block proposal duty more efficient

### DIFF
--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -29,7 +29,7 @@ from observability import (
 )
 from observability.api_client import RequestLatency, ServiceType
 from schemas import SchemaBeaconAPI, SchemaRemoteSigner, SchemaValidator
-from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
+from spec import SpecAttestation, SpecSyncCommittee
 from spec.attestation import AttestationData
 from spec.base import Genesis, SpecElectra, parse_spec
 from spec.constants import INTERVALS_PER_SLOT
@@ -736,7 +736,7 @@ class BeaconNode:
     async def publish_block_v2(
         self,
         fork_version: SchemaBeaconAPI.ForkVersion,
-        signed_beacon_block_contents: "SpecBeaconBlock.ElectraBlockContentsSigned",
+        signed_beacon_block_contents: SchemaBeaconAPI.ElectraBlockContentsSigned,
     ) -> None:
         with self.tracer.start_as_current_span(
             name=f"{self.__class__.__name__}.publish_block_v2",
@@ -748,7 +748,7 @@ class BeaconNode:
             await self._make_request(
                 method="POST",
                 endpoint="/eth/v2/beacon/blocks",
-                data=self.json_encoder.encode(signed_beacon_block_contents.to_obj()),
+                data=self.json_encoder.encode(signed_beacon_block_contents),
                 headers={
                     "Eth-Consensus-Version": fork_version.value,
                     "Content-Type": ContentType.JSON.value,
@@ -758,7 +758,7 @@ class BeaconNode:
     async def publish_blinded_block_v2(
         self,
         fork_version: SchemaBeaconAPI.ForkVersion,
-        signed_blinded_beacon_block: "SpecBeaconBlock.ElectraBlindedBlockSigned",
+        signed_blinded_beacon_block: SchemaBeaconAPI.SignedBeaconBlock,
     ) -> None:
         with self.tracer.start_as_current_span(
             name=f"{self.__class__.__name__}.publish_blinded_block_v2",
@@ -770,7 +770,7 @@ class BeaconNode:
             await self._make_request(
                 method="POST",
                 endpoint="/eth/v2/beacon/blinded_blocks",
-                data=self.json_encoder.encode(signed_blinded_beacon_block.to_obj()),
+                data=self.json_encoder.encode(signed_blinded_beacon_block),
                 headers={
                     "Eth-Consensus-Version": fork_version.value,
                     "Content-Type": ContentType.JSON.value,

--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -307,11 +307,11 @@ class MultiBeaconNode:
         Most of the logic in here makes sure we don't wait too long for a block to be
         produced by an unresponsive beacon node.
         """
-        # Times out at 1/3 of the SECONDS_PER_SLOT spec value into the slot
-        # (e.g. 1.33s for Ethereum, 0.55s for Gnosis Chain).
+        # Times out at 1/2 of the SECONDS_PER_SLOT spec value into the slot
+        # (e.g. 2s for Ethereum, 0.83s for Gnosis Chain).
         # If no block has been returned by that point, it waits indefinitely for the
         # first block to be returned by any beacon node.
-        timeout = (1 / 3) * self.SECONDS_PER_INTERVAL
+        timeout = (1 / 2) * self.SECONDS_PER_INTERVAL
 
         beacon_nodes_to_use = self.initialized_beacon_nodes
         if self.beacon_nodes_proposal:

--- a/src/schemas/beacon_api.py
+++ b/src/schemas/beacon_api.py
@@ -9,7 +9,7 @@ https://docs.nodereal.io/reference/eventstream
 """
 
 from enum import Enum
-from typing import Self
+from typing import Any, Self
 
 import msgspec
 
@@ -167,7 +167,18 @@ class ProduceBlockV3Response(msgspec.Struct):
     execution_payload_blinded: bool
     execution_payload_value: str
     consensus_block_value: str
-    data: dict  # type: ignore[type-arg]
+    data: dict[str, Any]
+
+
+class SignedBeaconBlock(msgspec.Struct):
+    message: dict[str, Any]
+    signature: str
+
+
+class ElectraBlockContentsSigned(msgspec.Struct):
+    signed_block: SignedBeaconBlock
+    kzg_proofs: list[str]
+    blobs: list[str]
 
 
 # Events

--- a/src/schemas/remote_signer.py
+++ b/src/schemas/remote_signer.py
@@ -46,7 +46,7 @@ class AttestationSignableMessage(SignableMessageWithForkInfo, kw_only=True):
 
 
 class Slot(msgspec.Struct):
-    slot: int
+    slot: str
 
 
 class AggregationSlotSignableMessage(SignableMessageWithForkInfo, kw_only=True):
@@ -65,7 +65,7 @@ class AggregateAndProofV2SignableMessage(SignableMessageWithForkInfo, kw_only=Tr
 
 
 class RandaoReveal(msgspec.Struct):
-    epoch: int
+    epoch: str
 
 
 class RandaoRevealSignableMessage(SignableMessageWithForkInfo, kw_only=True):
@@ -74,8 +74,8 @@ class RandaoRevealSignableMessage(SignableMessageWithForkInfo, kw_only=True):
 
 
 class BeaconBlockHeader(msgspec.Struct):
-    slot: int
-    proposer_index: int
+    slot: str
+    proposer_index: str
     parent_root: str
     state_root: str
     body_root: str
@@ -97,7 +97,7 @@ class BeaconBlockV2SignableMessage(SignableMessageWithForkInfo, kw_only=True):
 
 class SyncCommitteeMessage(msgspec.Struct):
     beacon_block_root: str
-    slot: int
+    slot: str
 
 
 class SyncCommitteeMessageSignableMessage(SignableMessageWithForkInfo, kw_only=True):
@@ -106,8 +106,8 @@ class SyncCommitteeMessageSignableMessage(SignableMessageWithForkInfo, kw_only=T
 
 
 class SyncAggregatorSelectionData(msgspec.Struct):
-    slot: int
-    subcommittee_index: int
+    slot: str
+    subcommittee_index: str
 
 
 class SyncCommitteeSelectionProofSignableMessage(

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -518,7 +518,7 @@ class AttestationService(ValidatorDutyService):
                 signable_messages.append(
                     SchemaRemoteSigner.AggregationSlotSignableMessage(
                         fork_info=_fork_info,
-                        aggregation_slot=SchemaRemoteSigner.Slot(slot=int(duty.slot)),
+                        aggregation_slot=SchemaRemoteSigner.Slot(slot=str(duty.slot)),
                     ),
                 )
                 identifiers.append(duty.pubkey)

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -186,7 +186,7 @@ class SyncCommitteeService(ValidatorDutyService):
                     fork_info=_fork_info,
                     sync_committee_message=SchemaRemoteSigner.SyncCommitteeMessage(
                         beacon_block_root=beacon_block_root,
-                        slot=duty_slot,
+                        slot=str(duty_slot),
                     ),
                 ),
                 identifier=validator.pubkey,
@@ -276,8 +276,8 @@ class SyncCommitteeService(ValidatorDutyService):
                         SchemaRemoteSigner.SyncCommitteeSelectionProofSignableMessage(
                             fork_info=_fork_info,
                             sync_aggregator_selection_data=SchemaRemoteSigner.SyncAggregatorSelectionData(
-                                slot=duty_slot,
-                                subcommittee_index=subcommittee_index,
+                                slot=str(duty_slot),
+                                subcommittee_index=str(subcommittee_index),
                             ),
                         ),
                         identifier=duty.pubkey,
@@ -306,8 +306,10 @@ class SyncCommitteeService(ValidatorDutyService):
 
                 duty_sync_committee_selection_proofs.append(
                     SchemaBeaconAPI.SyncDutySubCommitteeSelectionProof(
-                        slot=sel_proof_msg.sync_aggregator_selection_data.slot,
-                        subcommittee_index=sel_proof_msg.sync_aggregator_selection_data.subcommittee_index,
+                        slot=int(sel_proof_msg.sync_aggregator_selection_data.slot),
+                        subcommittee_index=int(
+                            sel_proof_msg.sync_aggregator_selection_data.subcommittee_index
+                        ),
                         is_aggregator=self._is_aggregator(selection_proof),
                         selection_proof=selection_proof,
                     ),


### PR DESCRIPTION
A few improvements

1. Prefetch RANDAO reveal value before the proposal duty slot starts
2. Perform fewer processing-heavy operations with remerkleable objects and instead use `msgspec.Struct` objects where possible
3. Allow for a bit more time for beacon nodes to return a block before determining the best block (up to 2s on Ethereum, 0.83s on Gnosis)
