### PR TITLE
Update ruff pre-commit hook id

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,8 @@ repos:
     rev: v0.11.11
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
-        types_or: [python]
-        require_serial: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.15.0'


### PR DESCRIPTION
The `ruff` hook id is now considered a legacy alias for the `ruff-check` hook id, see https://github.com/astral-sh/ruff-pre-commit/pull/124