### PR TITLE
Add host information to BeaconNode errors

### DIFF
--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -224,11 +224,11 @@ class BeaconNode:
         resp_text = await response.text()
 
         if response.status == 503:
-            raise BeaconNodeNotReady(resp_text)
+            raise BeaconNodeNotReady(response.request_info.url, resp_text)
         if response.status == 405:
-            raise BeaconNodeUnsupportedEndpoint(resp_text)
+            raise BeaconNodeUnsupportedEndpoint(response.request_info.url, resp_text)
         if response.status == 400:
-            raise BeaconNodeReturnedBadRequest(resp_text)
+            raise BeaconNodeReturnedBadRequest(response.request_info.url, resp_text)
 
         raise ValueError(
             f"Received status code {response.status} for request to {response.request_info.url}"


### PR DESCRIPTION
Makes it easier to tell from the logs which beacon node triggered the exception:

Before:
```
WARNING: Failed to get a response from beacon node: BeaconNodeReturnedBadRequest('{"code":400,"message":"invalid attestations","failures":[{"index":0,"message":"matching head block for attestation is not found"}]}')
```

After:
```
WARNING: Failed to get a response from beacon node: BeaconNodeReturnedBadRequest(URL('http://beacon-node-a:1234/eth/v2/beacon/pool/attestations'), '{"code":400,"message":"invalid attestations","failures":[{"index":0,"message":"matching head block for attestation is not found"}]}')
```