### PR TITLE
Refactor ERRORS_METRIC

### DIFF
--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from ._logging import setup_logging
 from ._metrics import setup_metrics
-from ._metrics_shared import ErrorType, get_shared_metrics
+from ._metrics_shared import ERRORS_METRIC, ErrorType
 from ._profiling import setup_profiling
 from ._tracing import setup_tracing
 from ._vero_info import get_service_commit, get_service_name, get_service_version
@@ -29,10 +29,10 @@ def init_observability(
 
 
 __all__ = [
+    "ERRORS_METRIC",
     "ErrorType",
     "get_service_commit",
     "get_service_name",
     "get_service_version",
-    "get_shared_metrics",
     "init_observability",
 ]

--- a/src/observability/_metrics_shared.py
+++ b/src/observability/_metrics_shared.py
@@ -2,9 +2,6 @@ from enum import Enum
 
 from prometheus_client import Counter
 
-_ERRORS_METRIC: Counter | None = None
-_METRICS_INITIALIZED = False
-
 
 class ErrorType(Enum):
     ATTESTATION_CONSENSUS = "attestation-consensus"
@@ -24,21 +21,10 @@ class ErrorType(Enum):
     OTHER = "other"
 
 
-def get_shared_metrics() -> tuple[Counter]:
-    global _ERRORS_METRIC, _METRICS_INITIALIZED
-
-    if not _METRICS_INITIALIZED:
-        _ERRORS_METRIC = Counter(
-            "errors",
-            "Number of errors",
-            labelnames=["error_type"],
-        )
-        for enum_type in ErrorType:
-            _ERRORS_METRIC.labels(enum_type.value).reset()
-
-        _METRICS_INITIALIZED = True
-
-    if _ERRORS_METRIC is None:
-        raise ValueError("_ERRORS_METRIC must be initialized")
-
-    return (_ERRORS_METRIC,)
+ERRORS_METRIC = Counter(
+    "errors",
+    "Number of errors",
+    labelnames=["error_type"],
+)
+for enum_type in ErrorType:
+    ERRORS_METRIC.labels(enum_type.value).reset()

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -24,10 +24,10 @@ from prometheus_client import Gauge, Histogram
 from yarl import URL
 
 from observability import (
+    ERRORS_METRIC,
     ErrorType,
     get_service_name,
     get_service_version,
-    get_shared_metrics,
 )
 from observability.api_client import RequestLatency, ServiceType
 from schemas import SchemaBeaconAPI, SchemaRemoteSigner, SchemaValidator
@@ -88,7 +88,6 @@ _CHECKPOINT_CONFIRMATIONS = CounterMetric(
     "Tracks how many times each beacon node confirmed finality checkpoints.",
     labelnames=["host"],
 )
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class BeaconNodeNotReady(Exception):
@@ -862,7 +861,7 @@ class BeaconNode:
                 try:
                     event_name = decoded.split(":")[1].strip()
                 except Exception as e:
-                    _ERRORS_METRIC.labels(
+                    ERRORS_METRIC.labels(
                         error_type=ErrorType.EVENT_CONSUMER.value,
                     ).inc()
                     self.logger.exception(

--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -45,7 +45,7 @@ from opentelemetry import trace
 from remerkleable.complex import Container
 
 from args import CLIArgs
-from observability import ErrorType, get_shared_metrics
+from observability import ERRORS_METRIC, ErrorType
 from schemas import SchemaBeaconAPI, SchemaValidator
 from spec import SpecAttestation, SpecBeaconBlock, SpecSyncCommittee
 from spec.base import SpecElectra
@@ -54,8 +54,6 @@ from spec.constants import INTERVALS_PER_SLOT
 from tasks import TaskManager
 
 from .beacon_node import BeaconNode
-
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class MultiBeaconNode:
@@ -642,7 +640,7 @@ class MultiBeaconNode:
             try:
                 yield await task
             except Exception as e:
-                _ERRORS_METRIC.labels(
+                ERRORS_METRIC.labels(
                     error_type=ErrorType.AGGREGATE_ATTESTATION_PRODUCE.value,
                 ).inc()
                 self.logger.exception(
@@ -734,7 +732,7 @@ class MultiBeaconNode:
             try:
                 yield await task
             except Exception:
-                _ERRORS_METRIC.labels(
+                ERRORS_METRIC.labels(
                     error_type=ErrorType.SYNC_COMMITTEE_CONTRIBUTION_PRODUCE.value,
                 ).inc()
 

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -12,7 +12,7 @@ from opentelemetry.trace import (
 )
 from prometheus_client import Counter
 
-from observability import ErrorType, get_shared_metrics
+from observability import ERRORS_METRIC, ErrorType
 from schemas import SchemaBeaconAPI, SchemaRemoteSigner
 from services.validator_duty_service import (
     ValidatorDuty,
@@ -26,7 +26,6 @@ _VC_PUBLISHED_BLOCKS = Counter(
     "Successfully published blocks",
 )
 _VC_PUBLISHED_BLOCKS.reset()
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class BlockProposalService(ValidatorDutyService):
@@ -285,7 +284,7 @@ class BlockProposalService(ValidatorDutyService):
                     ],
                 )
             except Exception as e:
-                _ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
+                ERRORS_METRIC.labels(error_type=ErrorType.SIGNATURE.value).inc()
                 self.logger.exception(
                     f"Failed to get signature for validator registrations: {e!r}",
                 )
@@ -383,7 +382,7 @@ class BlockProposalService(ValidatorDutyService):
                 try:
                     randao_reveal = await self._get_randao_reveal(duty=duty)
                 except Exception as e:
-                    _ERRORS_METRIC.labels(
+                    ERRORS_METRIC.labels(
                         error_type=ErrorType.SIGNATURE.value,
                     ).inc()
                     self.logger.exception(
@@ -417,7 +416,7 @@ class BlockProposalService(ValidatorDutyService):
                         randao_reveal=randao_reveal,
                     )
                 except Exception as e:
-                    _ERRORS_METRIC.labels(
+                    ERRORS_METRIC.labels(
                         error_type=ErrorType.BLOCK_PRODUCE.value,
                     ).inc()
                     self.logger.exception(
@@ -456,7 +455,7 @@ class BlockProposalService(ValidatorDutyService):
                         identifier=duty.pubkey,
                     )
                 except Exception as e:
-                    _ERRORS_METRIC.labels(
+                    ERRORS_METRIC.labels(
                         error_type=ErrorType.SIGNATURE.value,
                     ).inc()
                     self.logger.exception(
@@ -496,7 +495,7 @@ class BlockProposalService(ValidatorDutyService):
                             ),
                         )
                 except Exception as e:
-                    _ERRORS_METRIC.labels(
+                    ERRORS_METRIC.labels(
                         error_type=ErrorType.BLOCK_PUBLISH.value,
                     ).inc()
                     self.logger.exception(

--- a/src/services/event_consumer.py
+++ b/src/services/event_consumer.py
@@ -9,12 +9,10 @@ from uuid import uuid4
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from prometheus_client import Counter, Histogram
 
-from observability import ErrorType, get_shared_metrics
+from observability import ERRORS_METRIC, ErrorType
 from providers import BeaconChain, BeaconNode
 from schemas import SchemaBeaconAPI
 from tasks import TaskManager
-
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 def _setup_head_event_time_metric(
@@ -212,7 +210,7 @@ class EventConsumerService:
             raise
         except Exception as e:
             beacon_node.score -= BeaconNode.SCORE_DELTA_FAILURE
-            _ERRORS_METRIC.labels(
+            ERRORS_METRIC.labels(
                 error_type=ErrorType.EVENT_CONSUMER.value,
             ).inc()
             self.logger.exception(

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -10,7 +10,7 @@ from opentelemetry import trace
 from prometheus_client import Histogram
 
 from args import CLIArgs
-from observability import ErrorType, get_shared_metrics
+from observability import ERRORS_METRIC, ErrorType
 from providers import (
     BeaconChain,
     DutyCache,
@@ -23,8 +23,6 @@ from tasks import TaskManager
 
 if TYPE_CHECKING:
     from services import ValidatorStatusTrackerService
-
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class ValidatorDuty(Enum):
@@ -212,7 +210,7 @@ class ValidatorDutyService:
                 await self._update_duties()
                 break
             except Exception as e:
-                _ERRORS_METRIC.labels(error_type=ErrorType.DUTIES_UPDATE.value).inc()
+                ERRORS_METRIC.labels(error_type=ErrorType.DUTIES_UPDATE.value).inc()
                 self.logger.exception(
                     f"Failed to update duties: {e!r}",
                 )

--- a/src/services/validator_status_tracker.py
+++ b/src/services/validator_status_tracker.py
@@ -4,7 +4,7 @@ import logging
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from prometheus_client import Gauge
 
-from observability import ErrorType, get_shared_metrics
+from observability import ERRORS_METRIC, ErrorType
 from providers import BeaconChain, MultiBeaconNode, SignatureProvider
 from schemas import SchemaBeaconAPI, SchemaValidator
 from schemas.validator import (
@@ -28,7 +28,6 @@ _SLASHING_DETECTED = Gauge(
     multiprocess_mode="max",
 )
 _SLASHING_DETECTED.set(0)
-(_ERRORS_METRIC,) = get_shared_metrics()
 
 
 class ValidatorStatusTrackerService:
@@ -202,7 +201,7 @@ class ValidatorStatusTrackerService:
                 await self._update_validator_statuses()
                 break
             except Exception as e:
-                _ERRORS_METRIC.labels(
+                ERRORS_METRIC.labels(
                     error_type=ErrorType.VALIDATOR_STATUS_UPDATE.value
                 ).inc()
                 self.logger.exception(

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -4,9 +4,7 @@ from collections.abc import Coroutine
 from functools import partial
 from typing import Any
 
-from observability import ErrorType, get_shared_metrics
-
-(_ERRORS_METRIC,) = get_shared_metrics()
+from observability import ERRORS_METRIC, ErrorType
 
 
 class TaskManager:
@@ -27,7 +25,7 @@ class TaskManager:
             self.logger.exception(
                 f"Task {task} failed with exception {e!r}",
             )
-            _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
+            ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
 
     def task_done_callback(self, task: asyncio.Task[Any]) -> None:
         try:
@@ -38,7 +36,7 @@ class TaskManager:
                 self.logger.exception(
                     f"Task {task} was cancelled",
                 )
-                _ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
+                ERRORS_METRIC.labels(error_type=ErrorType.OTHER.value).inc()
         else:
             if exc is not None:
                 self._log_task_exception(task)


### PR DESCRIPTION
Removes the `get_shared_metrics` function and uses the `ERRORS_METRIC` variable directly wherever needed.