### PR TITLE
Add `TaskManager.add_existing_task` method

### DIFF
--- a/src/providers/beacon_chain.py
+++ b/src/providers/beacon_chain.py
@@ -77,7 +77,7 @@ class BeaconChain:
         self.logger.info(f"Ready for Electra at epoch {self.ELECTRA_FORK_EPOCH}")
 
     def start_slot_ticker(self) -> None:
-        self.task_manager.submit_task(self.on_new_slot())
+        self.task_manager.create_task(self.on_new_slot())
 
     def get_timestamp_for_slot(self, slot: int) -> int:
         return self.genesis_time + slot * self.SECONDS_PER_SLOT
@@ -126,10 +126,10 @@ class BeaconChain:
                 self.logger.info(f"Electra fork epoch reached! {ELECTRA_ASCII_ART}")
 
         for handler in self.new_slot_handlers:
-            self.task_manager.submit_task(handler(_current_slot, _is_new_epoch))
+            self.task_manager.create_task(handler(_current_slot, _is_new_epoch))
 
         await self.wait_for_next_slot()
-        self.task_manager.submit_task(self.on_new_slot())
+        self.task_manager.create_task(self.on_new_slot())
 
     def time_since_slot_start(self, slot: int) -> float:
         return time.time() - self.get_timestamp_for_slot(slot)

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -214,7 +214,7 @@ class BeaconNode:
                 f"Failed to initialize beacon node at {self.base_url}: {e!r}",
             )
             # Try to initialize again in 30 seconds
-            self.task_manager.submit_task(self.initialize_full(), delay=30.0)
+            self.task_manager.create_task(self.initialize_full(), delay=30.0)
 
     @staticmethod
     async def _handle_nok_status_code(response: aiohttp.ClientResponse) -> None:

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -78,7 +78,7 @@ class AttestationService(ValidatorDutyService):
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
-            self.task_manager.submit_task(self.update_duties())
+            self.task_manager.create_task(self.update_duties())
 
         return self
 
@@ -121,7 +121,7 @@ class AttestationService(ValidatorDutyService):
 
         # At the start of an epoch, update duties
         if is_new_epoch:
-            self.task_manager.submit_task(super().update_duties())
+            self.task_manager.create_task(super().update_duties())
 
     async def handle_head_event(
         self, event: SchemaBeaconAPI.HeadEvent, beacon_node_host: str
@@ -136,7 +136,7 @@ class AttestationService(ValidatorDutyService):
             self.logger.debug(
                 "Head event duty dependent root mismatch -> updating duties",
             )
-            self.task_manager.submit_task(super().update_duties())
+            self.task_manager.create_task(super().update_duties())
 
         # Ignore the head event if we've already started attesting - it's either:
         # A) too late (entirely possible with a block that was proposed late / did not propagate well)
@@ -246,7 +246,7 @@ class AttestationService(ValidatorDutyService):
             )
 
         # Use the AttestationData later on for aggregation duties
-        self.task_manager.submit_task(
+        self.task_manager.create_task(
             self.prepare_and_aggregate_attestations(
                 slot=slot,
                 att_data=att_data,
@@ -531,7 +531,7 @@ class AttestationService(ValidatorDutyService):
             for duty in duties_with_proofs
         ]
 
-        self.task_manager.submit_task(
+        self.task_manager.create_task(
             self.multi_beacon_node.prepare_beacon_committee_subscriptions(
                 data=beacon_committee_subscriptions_data,
             ),

--- a/src/services/block_proposal.py
+++ b/src/services/block_proposal.py
@@ -51,9 +51,9 @@ class BlockProposalService(ValidatorDutyService):
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
-            self.task_manager.submit_task(self.update_duties())
+            self.task_manager.create_task(self.update_duties())
 
-        self.task_manager.submit_task(self.prepare_beacon_proposer())
+        self.task_manager.create_task(self.prepare_beacon_proposer())
         return self
 
     async def __aexit__(
@@ -132,12 +132,12 @@ class BlockProposalService(ValidatorDutyService):
             await self._fetch_randao_reveal(duty=duty_for_next_slot)
 
         if self.cli_args.use_external_builder:
-            self.task_manager.submit_task(self.register_validators(current_slot=slot))
+            self.task_manager.create_task(self.register_validators(current_slot=slot))
 
         # At the start of an epoch, update duties
         if is_new_epoch:
-            self.task_manager.submit_task(super().update_duties())
-            self.task_manager.submit_task(self.prepare_beacon_proposer())
+            self.task_manager.create_task(super().update_duties())
+            self.task_manager.create_task(self.prepare_beacon_proposer())
 
     async def handle_head_event(self, event: SchemaBeaconAPI.HeadEvent, _: str) -> None:
         if (
@@ -147,7 +147,7 @@ class BlockProposalService(ValidatorDutyService):
             self.logger.info(
                 "Head event duty dependent root mismatch -> updating duties",
             )
-            self.task_manager.submit_task(super().update_duties())
+            self.task_manager.create_task(super().update_duties())
 
     def _prune_duties(self) -> None:
         current_epoch = self.beacon_chain.current_epoch

--- a/src/services/sync_committee.py
+++ b/src/services/sync_committee.py
@@ -60,7 +60,7 @@ class SyncCommitteeService(ValidatorDutyService):
         finally:
             # The cached duties may be stale - call update_duties even if
             # we loaded duties from cache
-            self.task_manager.submit_task(self.update_duties())
+            self.task_manager.create_task(self.update_duties())
 
         return self
 
@@ -103,7 +103,7 @@ class SyncCommitteeService(ValidatorDutyService):
 
         # At the start of an epoch, update duties
         if is_new_epoch:
-            self.task_manager.submit_task(super().update_duties())
+            self.task_manager.create_task(super().update_duties())
 
     async def handle_head_event(self, event: SchemaBeaconAPI.HeadEvent, _: str) -> None:
         await self.produce_sync_message_if_not_yet_produced(
@@ -222,7 +222,7 @@ class SyncCommitteeService(ValidatorDutyService):
         # Add the aggregation duty to the schedule *before*
         # publishing sync messages so that any delays in publishing
         # do not affect the aggregation duty start time
-        self.task_manager.submit_task(
+        self.task_manager.create_task(
             self.prepare_and_aggregate_sync_messages(
                 duty_slot=duty_slot,
                 beacon_block_root=beacon_block_root,
@@ -539,7 +539,7 @@ class SyncCommitteeService(ValidatorDutyService):
                 )
                 for duty in self.sync_duties[sync_period]
             ]
-            self.task_manager.submit_task(
+            self.task_manager.create_task(
                 self.multi_beacon_node.prepare_sync_committee_subscriptions(
                     data=sync_committee_subscriptions_data,
                 )

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -149,7 +149,7 @@ class ValidatorDutyService:
         self.logger.debug(
             f"Handling reorg event at slot {event.slot}, new head block {event.new_head_block}"
         )
-        self.task_manager.submit_task(self.update_duties())
+        self.task_manager.create_task(self.update_duties())
 
     @property
     def has_ongoing_duty(self) -> bool:

--- a/src/services/validator_status_tracker.py
+++ b/src/services/validator_status_tracker.py
@@ -59,7 +59,7 @@ class ValidatorStatusTrackerService:
         # to continue initializing the validator client since we don't know
         # which validators to retrieve duties for.
         await self._update_validator_statuses(minimal_update=True)
-        self.task_manager.submit_task(self.update_validator_statuses())
+        self.task_manager.create_task(self.update_validator_statuses())
 
     @property
     def active_or_pending_indices(self) -> list[int]:
@@ -79,7 +79,7 @@ class ValidatorStatusTrackerService:
         # (before duties are updated)
         slots_per_epoch = self.beacon_chain.SLOTS_PER_EPOCH
         if slot % slots_per_epoch == slots_per_epoch - 1:
-            self.task_manager.submit_task(self.update_validator_statuses())
+            self.task_manager.create_task(self.update_validator_statuses())
 
     async def handle_slashing_event(
         self,

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -55,7 +55,7 @@ def shutdown_handler(
     task_manager: TaskManager,
 ) -> None:
     _logger.info(f"Received shutdown signal {signal.Signals(signo).name}")
-    task_manager.submit_task(
+    task_manager.create_task(
         shut_down(
             validator_duty_services=validator_duty_services,
             shutdown_event=shutdown_event,

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -46,17 +46,13 @@ class TaskManager:
             # Remove the task from the set once it's done
             self._tasks.discard(task)
 
-    def submit_task(
+    def create_task(
         self,
         coro: Coroutine[Any, Any, None],
         delay: float = 0.0,
         name: str | None = None,
     ) -> None:
         """Create and track a task from the given coroutine."""
-        if self.shutdown_event.is_set():
-            self.logger.debug(f"Cancelling task {name!r}, shutting down...")
-            asyncio.create_task(coro).cancel()
-            return
 
         async def _delayed_coro() -> None:
             if delay > 0:
@@ -64,6 +60,18 @@ class TaskManager:
             await coro
 
         task: asyncio.Task[None] = asyncio.create_task(_delayed_coro(), name=name)
+        self.add_existing_task(task=task)
+
+    def add_existing_task(
+        self,
+        task: asyncio.Task[Any],
+    ) -> None:
+        """Track an existing task, ensuring it is not garbage collected."""
+        if self.shutdown_event.is_set():
+            self.logger.debug(f"Cancelling task {task}, shutting down...")
+            task.cancel()
+            return
+
         task.add_done_callback(partial(self.task_done_callback))
         self._tasks.add(task)
 


### PR DESCRIPTION
The new method can be used to track existing tasks (created elsewhere), ensuring they're not garbage collected.