### PR TITLE
Use `${{ github.repository }}` in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
       id: docker_metadata
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
-        images: ghcr.io/${{ github.repository_owner }}/vero
+        images: ghcr.io/${{ github.repository }}
         tags: |
           # reflects the last commit on the `master` branch
           type=ref,event=branch


### PR DESCRIPTION
This makes the workflow file generic, making it possible to share the exact same workflow across different repositories