### PR TITLE
Generate build provenance and SBOM attestations for Vero container images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # The permissions below are needed
+      # only for generating attestations
       id-token: write
       attestations: write
 
@@ -68,4 +70,18 @@ jobs:
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         subject-digest: ${{ steps.build_and_push.outputs.digest }}
+        push-to-registry: true
+
+    - name: Generate SBOM
+      uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
+      with:
+        image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        output-file: 'sbom.json'
+
+    - name: Generate SBOM attestation
+      uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        subject-digest: ${{ steps.build_and_push.outputs.digest }}
+        sbom-path: 'sbom.json'
         push-to-registry: true


### PR DESCRIPTION
Generates [artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) as part of our Docker release workflow, allowing users to verify the build provenance and SBOM (Software Bill of Materials) of our published container images.

Vero users can then implement security policies that require these kinds of attestations to be provided before allowing our container images to run, e.g. using `gh attestation verify` or a [Kubernetes Sigstore Policy Controller](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/enforce-artifact-attestations), or check the SBOM for CVEs.

___

An example of the artifact and attestations can be seen in the results of this action run: https://github.com/serenita-org/vero/actions/runs/18428368435 . 

The action built [an image](https://github.com/serenita-org/vero/pkgs/container/vero/541445447?tag=build-provenance) with the following digest: ` sha256:9981da1c16fd7969bca97763ab0fb55ee5a04d3365fdc8ac576293510f299508 `

Build provenance [attestation](https://github.com/serenita-org/vero/attestations/11804275) and verification:

<img width="972" height="346" alt="image" src="https://github.com/user-attachments/assets/b6076bfa-e36a-4912-8a65-d2c1d9f31cc0" />

SBOM [attestation](https://github.com/serenita-org/vero/attestations/11804282) and verification:

<img width="980" height="362" alt="image" src="https://github.com/user-attachments/assets/5a070660-deb8-489b-91e7-fc07d1e78216" />
