### PR TITLE
Add pip-audit workflow that runs daily

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,22 @@
+name: pip-audit
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Runs every day at 01:23
+    - cron: "23 1 * * *"
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+
+    - run: uvx pip-audit -r requirements.txt --disable-pip


### PR DESCRIPTION
We're already using GitHub's Dependabot alerts so this mostly just serves as a fail-safe.