### PR TITLE
Only confirm checkpoint early if a duty is scheduled later

### DIFF
--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -194,18 +194,20 @@ class AttestationService(ValidatorDutyService):
 
         if len(slot_attester_duties) == 0:
             self.logger.debug(f"No remaining attester duties for slot {slot}")
-            # Produce attestation data even if no attester duty is scheduled.
-            # This ensures finality checkpoints are confirmed and cached early into
-            # the epoch, even when managing a low number of validators.
-            _ = await asyncio.wait_for(
-                self.attestation_data_provider.produce_attestation_data(
-                    slot=slot,
-                    head_event_block_root=head_event.block if head_event else None,
-                ),
-                timeout=self.beacon_chain.get_timestamp_for_slot(slot + 1)
-                - time.time(),
-            )
-            return
+            if len(self.attester_duties[epoch]) > 0:
+                # Produce attestation data if there is an attester
+                # duty scheduled for later in the epoch.
+                # This ensures finality checkpoints are confirmed and cached early
+                # into the epoch, even with a low number of active validators.
+                _ = await asyncio.wait_for(
+                    self.attestation_data_provider.produce_attestation_data(
+                        slot=slot,
+                        head_event_block_root=head_event.block if head_event else None,
+                    ),
+                    timeout=self.beacon_chain.get_timestamp_for_slot(slot + 1)
+                    - time.time(),
+                )
+                return
 
         self.logger.debug(
             f"Attesting for {slot=}, {head_event=}, {len(slot_attester_duties)} duties",


### PR DESCRIPTION
Avoids checkpoint confirmation if no duty is scheduler later in the epoch. Without this condition, confirmation was attempted even when the connected beacon node was still syncing which led to a lot of spam in the logs.