### PR TITLE
Reduce number of open file descriptors in tests

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -124,10 +124,10 @@ async def run_services(
 ) -> None:
     spec = load_spec(cli_args=cli_args)
 
-    db = DB(data_dir=cli_args.data_dir)
-    db.run_migrations()
-
     async with contextlib.AsyncExitStack() as exit_stack:
+        db = exit_stack.enter_context(DB(data_dir=cli_args.data_dir))
+        db.run_migrations()
+
         multi_beacon_node = await exit_stack.enter_async_context(
             MultiBeaconNode(
                 beacon_node_urls=cli_args.beacon_node_urls,

--- a/src/providers/db/db.py
+++ b/src/providers/db/db.py
@@ -2,7 +2,8 @@ import logging
 import sqlite3
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from types import TracebackType
+from typing import Any, Self
 
 from providers.db.migrations import MIGRATIONS, DbMigration
 
@@ -30,6 +31,17 @@ class DB:
                 # DB does not exist yet
                 return -1
             raise
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.connection.close()
 
     def run_migration_statements(self, migration: DbMigration) -> None:
         self.logger.info(f"Migrating to version {migration.version}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,10 +208,10 @@ async def task_manager(
 
 
 @pytest.fixture
-def empty_db(tmp_path: Path) -> DB:
-    db = DB(data_dir=str(tmp_path))
-    db.run_migrations()
-    return db
+def empty_db(tmp_path: Path) -> Generator[DB, None]:
+    with DB(data_dir=str(tmp_path)) as db:
+        db.run_migrations()
+        yield db
 
 
 @pytest.fixture(scope="session")

--- a/tests/providers/db/test_db.py
+++ b/tests/providers/db/test_db.py
@@ -7,57 +7,69 @@ from providers.db.migrations import MIGRATIONS
 
 
 def test_db_run_migrations_empty_db(tmp_path: Path) -> None:
-    db = DB(data_dir=str(tmp_path))
-    assert db.current_version == -1
-    db.run_migrations()
-    assert db.current_version == 2
-    assert db.current_version == max(m.version for m in MIGRATIONS)
+    with DB(data_dir=str(tmp_path)) as db:
+        assert db.current_version == -1
+        db.run_migrations()
+        assert db.current_version == 2
+        assert db.current_version == max(m.version for m in MIGRATIONS)
 
 
 def test_db_run_migrations_with_data_in_db(tmp_path: Path) -> None:
-    db = DB(data_dir=str(tmp_path))
-    assert db.current_version == -1
-    db.run_migration_statements(migration=next(m for m in MIGRATIONS if m.version == 1))
-    assert db.current_version == 1
+    with DB(data_dir=str(tmp_path)) as db:
+        assert db.current_version == -1
+        db.run_migration_statements(
+            migration=next(m for m in MIGRATIONS if m.version == 1)
+        )
+        assert db.current_version == 1
 
-    db.run_migration_statements(migration=next(m for m in MIGRATIONS if m.version == 2))
-    assert db.current_version == 2
-    data = [
-        ("0x" + "a" * 96, "http://remote-signer-1:9000", None, None, None),
-        (
-            "0x" + "b" * 96,
-            "http://remote-signer-1:9000",
-            "0x" + "a" * 40,
-            "50000000",
-            "custom-graffiti",
-        ),
-        ("0x" + "c" * 96, "http://remote-signer-2:9000", "0x" + "0" * 40, None, None),
-        ("0x" + "d" * 96, "http://remote-signer-2:9000", None, "100000000", None),
-        ("0x" + "e" * 96, "http://remote-signer-2:9000", None, None, "my-graffiti"),
-    ]
-    with db.connection as conn:
-        conn.executemany("""INSERT INTO keymanager_data VALUES (?, ?, ?, ?, ?)""", data)
+        db.run_migration_statements(
+            migration=next(m for m in MIGRATIONS if m.version == 2)
+        )
+        assert db.current_version == 2
+        data = [
+            ("0x" + "a" * 96, "http://remote-signer-1:9000", None, None, None),
+            (
+                "0x" + "b" * 96,
+                "http://remote-signer-1:9000",
+                "0x" + "a" * 40,
+                "50000000",
+                "custom-graffiti",
+            ),
+            (
+                "0x" + "c" * 96,
+                "http://remote-signer-2:9000",
+                "0x" + "0" * 40,
+                None,
+                None,
+            ),
+            ("0x" + "d" * 96, "http://remote-signer-2:9000", None, "100000000", None),
+            ("0x" + "e" * 96, "http://remote-signer-2:9000", None, None, "my-graffiti"),
+        ]
+        with db.connection as conn:
+            conn.executemany(
+                """INSERT INTO keymanager_data VALUES (?, ?, ?, ?, ?)""", data
+            )
 
-    # Add data to tables here when you introduce new tables in a DB migration
+        # Add data to tables here when you introduce new tables in a DB migration
 
-    assert db.current_version == max(m.version for m in MIGRATIONS)
+        assert db.current_version == max(m.version for m in MIGRATIONS)
 
 
 def test_too_many_host_params(tmp_path: Path) -> None:
-    db = DB(data_dir=str(tmp_path))
-    db.run_migrations()
+    with DB(data_dir=str(tmp_path)) as db:
+        db.run_migrations()
 
-    parameters = [str(i) for i in range(50_000)]
+        parameters = [str(i) for i in range(50_000)]
 
-    with pytest.raises(ValueError, match=r"Too many host parameters provided"):
-        db.fetch_all(
-            f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in parameters)});",
-            parameters=parameters,
-        )
+        with pytest.raises(ValueError, match=r"Too many host parameters provided"):
+            db.fetch_all(
+                f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in parameters)});",
+                parameters=parameters,
+            )
 
-    # Smaller batches work just fine
-    for batch in db.batch_host_parameters(parameters):
-        db.fetch_all(
-            f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in batch)});",
-            parameters=batch,
-        )
+        # Smaller batches work just fine
+        for batch in db.batch_host_parameters(parameters):
+            db.fetch_all(
+                f"SELECT * from keymanager_data WHERE pubkey IN ({','.join('?' for _ in batch)});",
+                parameters=batch,
+            )


### PR DESCRIPTION
This is not an issue during Vero's normal runtime since the DB provider is only instantiated once.

However, when running tests, the DB provider gets instantiated many times which results in many open file descriptors.