### PR TITLE
Do not try to add SBOM to release assets

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,7 @@ jobs:
       with:
         image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         output-file: 'sbom.json'
+        upload-release-assets: false
 
     - name: Generate SBOM attestation
       uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0


### PR DESCRIPTION
The default value of `upload-release-assets: true` makes the docker workflow fail when run as part of a release. There's no real need to attach the SBOM to a release since the SBOM is also pushed to the container registry. Also, attaching may not even be possible since the releases are immutable. 