### PR TITLE
Limit worker count for ProcessPoolExecutor

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import os
 import time
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -148,7 +149,9 @@ async def run_services(
             genesis_timestamp=beacon_chain.get_timestamp_for_slot(0)
         )
 
-        process_pool_executor = ProcessPoolExecutor()
+        process_pool_executor = ProcessPoolExecutor(
+            max_workers=int(os.getenv("PYTHON_CPU_COUNT", "1"))
+        )
         keymanager = Keymanager(
             db=db,
             beacon_chain=beacon_chain,


### PR DESCRIPTION
Without limiting the ProcessPoolExecutor's worker count, Vero can end up using unnecessarily large amounts of memory.

Since the executor is only used to offload large numbers of signing requests off the main thread, a worker count of 1 should be sufficient.

This PR sets the worker count to 1 and allows it to be overridden using the `PYTHON_CPU_COUNT` environment variable, mimicking Python 3.13+ behavior (Vero currently uses Python 3.12).