### PR TITLE
Use text/plain header for signature requests

### DIFF
--- a/src/providers/_headers.py
+++ b/src/providers/_headers.py
@@ -5,3 +5,4 @@ class ContentType(Enum):
     JSON = "application/json"
     MSGPACK = "application/vnd.msgpack"
     OCTET_STREAM = "application/octet-stream"
+    TEXT_PLAIN = "text/plain"

--- a/tests/mock_api/remote_signer.py
+++ b/tests/mock_api/remote_signer.py
@@ -30,7 +30,7 @@ def _mocked_remote_signer_endpoints(
         )
 
     def _mocked_sign_endpoint(url: URL, **kwargs: Any) -> CallbackResult:
-        return CallbackResult(payload={"signature": "0x" + os.urandom(96).hex()})
+        return CallbackResult(body="0x" + os.urandom(96).hex())
 
     mocked_responses.get(
         url=re.compile("http://remote-signer:1234/api/v1/eth2/publicKeys"),


### PR DESCRIPTION
The remote signing API supports the `text/plain` content type for its `/api/v1/eth2/sign/{identifier}` endpoint. Using it saves a little bit of encoding/decoding on both server and client side.