### PR TITLE
Add `--ignore-spec-mismatch` flag

### DIFF
--- a/docs/docs/reference/changelog.md
+++ b/docs/docs/reference/changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming release
 
+#### Features
+- Add `--ignore-spec-mismatch` flag
 
 
 ## v1.3.1 { id="v1.3.1" }

--- a/docs/docs/reference/cli_reference.md
+++ b/docs/docs/reference/cli_reference.md
@@ -214,6 +214,17 @@ The logging level to use, one of `CRITICAL, ERROR, WARNING, INFO, DEBUG`. Defaul
 
 ___
 
+#### `--ignore-spec-mismatch`
+
+Ignores a mismatch between spec values returned by a beacon node and
+spec values included in Vero (which normally prevents such beacon nodes
+from being used).
+
+This flag can be used when a beacon node does not yet support new spec
+values (e.g. for upcoming network upgrades).
+
+___
+
 ### Dangerous Flags
 
 ??? danger "Expand"

--- a/src/args.py
+++ b/src/args.py
@@ -34,6 +34,7 @@ class CLIArgs(msgspec.Struct, kw_only=True):
     metrics_address: str
     metrics_port: int
     log_level: int
+    ignore_spec_mismatch: bool
     disable_slashing_detection: bool
 
 
@@ -267,6 +268,18 @@ def get_parser() -> argparse.ArgumentParser:
         help="The logging level to use. Defaults to INFO.",
     )
     parser.add_argument(
+        "--ignore-spec-mismatch",
+        action="store_true",
+        help="""
+        Ignores a mismatch between spec values returned by a beacon node and
+        spec values included in Vero (which normally prevents such beacon nodes
+        from being used).
+
+        This flag can be used when a beacon node does not yet support new spec
+        values (e.g. for upcoming network upgrades).
+        """,
+    )
+    parser.add_argument(
         "----DANGER----disable-slashing-detection",
         action="store_true",
         help="[DANGEROUS] Disables Vero's proactive slashing detection.",
@@ -345,6 +358,7 @@ def parse_cli_args(args: Sequence[str]) -> CLIArgs:
             metrics_address=parsed_args.metrics_address,
             metrics_port=parsed_args.metrics_port,
             log_level=logging.getLevelName(parsed_args.log_level),
+            ignore_spec_mismatch=parsed_args.ignore_spec_mismatch,
             disable_slashing_detection=parsed_args.DANGER____disable_slashing_detection,
         )
     except ValueError as e:

--- a/src/providers/beacon_node.py
+++ b/src/providers/beacon_node.py
@@ -71,6 +71,7 @@ class BeaconNode:
 
         self.spec = vero.spec
         self.SECONDS_PER_INTERVAL = int(self.spec.SECONDS_PER_SLOT) / INTERVALS_PER_SLOT
+        self._ignore_spec_mismatch = vero.cli_args.ignore_spec_mismatch
 
         self.scheduler = vero.scheduler
         self.task_manager = vero.task_manager
@@ -119,7 +120,7 @@ class BeaconNode:
     async def _initialize_full(self) -> None:
         # Raise if the spec returned by the beacon node differs
         bn_spec = await self.get_spec()
-        if self.spec != bn_spec:
+        if self.spec != bn_spec and not self._ignore_spec_mismatch:
             msg = f"Spec values returned by beacon node {self.host} not equal to hardcoded spec values:"
             for field in self.spec.fields():
                 if getattr(self.spec, field) != getattr(bn_spec, field):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def cli_args(
     attestation_consensus_threshold = indirect_params.get(
         "attestation_consensus_threshold", None
     )
+    ignore_spec_mismatch = indirect_params.get("ignore_spec_mismatch", False)
 
     return CLIArgs(
         network=Network._TESTS,
@@ -94,6 +95,7 @@ def cli_args(
         metrics_address="localhost",
         metrics_port=8000,
         log_level=logging.INFO,
+        ignore_spec_mismatch=ignore_spec_mismatch,
         disable_slashing_detection=False,
     )
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -408,6 +408,7 @@ def test_parse_cli_args_full_set() -> None:
         "--metrics-address=1.2.3.4",
         "--metrics-port=4321",
         "--log-level=DEBUG",
+        "--ignore-spec-mismatch",
         "----DANGER----disable-slashing-detection",
     ]
     expected_attr_values = {
@@ -431,6 +432,7 @@ def test_parse_cli_args_full_set() -> None:
         "metrics_address": "1.2.3.4",
         "metrics_port": 4321,
         "log_level": logging.DEBUG,
+        "ignore_spec_mismatch": True,
         "disable_slashing_detection": True,
     }
 
@@ -489,6 +491,7 @@ def test_parse_cli_args_minimal_set_with_defaults() -> None:
         metrics_address="localhost",
         metrics_port=8000,
         log_level=logging.INFO,
+        ignore_spec_mismatch=False,
         disable_slashing_detection=False,
     )
 


### PR DESCRIPTION
Adds a new CLI flag that can be used when Vero's spec values do not exactly match spec values provided by beacon nodes. This flag should not need to be provided often, but can be helpful when some CL clients do not yet provide all spec values (e.g. around network upgrades).


#### Related Issues

Resolves #257 

___

- [x] Changelog updated
