### PR TITLE
Log number of validators during initialization

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -148,7 +148,6 @@ async def run_services(vero: Vero) -> None:
         vero.beacon_chain.new_slot_handlers.append(
             validator_status_tracker_service.on_new_slot
         )
-        _logger.info("Initialized validator status tracker")
 
         if vero.cli_args.enable_doppelganger_detection:
             try:

--- a/src/services/validator_status_tracker.py
+++ b/src/services/validator_status_tracker.py
@@ -26,7 +26,7 @@ class ValidatorStatusTrackerService:
         self.scheduler = vero.scheduler
         self.task_manager = vero.task_manager
 
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger("ValidatorStatusTracker")
         self.metrics = vero.metrics
 
         self._slashing_detected = False
@@ -140,6 +140,9 @@ class ValidatorStatusTrackerService:
             self.logger.warning("No active or pending validators detected")
 
         if minimal_update:
+            self.logger.info(
+                f"Validators: {len(active_pubkeys)} active, {len(pending_pubkeys)} pending (total: {len(managed_pubkeys)})",
+            )
             return
 
         self.exited_validators = await self.multi_beacon_node.get_validators(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,27 +79,25 @@ async def test_lifecycle(
     required_log_lines = [
         "Initialized beacon node",
         "Current slot: ",
-        "Initialized validator status tracker",
         "Started validator duty services",
         "Subscribing to events",
-        "Updated duties",
-        "Published block for slot",
-        "Published attestations for slot",
-        "Published sync committee messages for slot",
     ]
 
     if enable_keymanager_api:
-        # Slightly fewer checks for this mode since it's not that easy
-        # to register validator keys from inside this test
-        for line in (
-            "Updated duties",
-            "Published block for slot",
-            "Published attestations for slot",
-            "Published sync committee messages for slot",
-        ):
-            required_log_lines.remove(line)
-
+        # It's not that easy to register validator keys from inside this test
+        # for the Keymanager mode. So we'll not actually expect to perform duties
+        # from within this test.
         required_log_lines.append("No active or pending validators detected")
+    else:
+        required_log_lines.extend(
+            [
+                "Validators: 4 active, 1 pending (total: 5)",
+                "Updated duties",
+                "Published block for slot",
+                "Published attestations for slot",
+                "Published sync committee messages for slot",
+            ]
+        )
 
     timeout = 5
     start = asyncio.get_running_loop().time()


### PR DESCRIPTION
Replaces the "Initialized validator status tracker" log line with a more informative one during Vero's initialization:

> 2026-01-26 13:35:15,601 - ValidatorStatusTracker - INFO : Validators: 4 active, 1 pending (total: 5)