### PR TITLE
VERO-01 Handle reorg events in `AttestationDataProvider`

### DIFF
--- a/src/initialize.py
+++ b/src/initialize.py
@@ -58,6 +58,7 @@ def _register_event_handlers(
 
     for reorg_handler_service in (
         attestation_service,
+        attestation_service.attestation_data_provider,
         block_proposal_service,
         sync_committee_service,
     ):

--- a/src/providers/attestation_data_provider.py
+++ b/src/providers/attestation_data_provider.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import logging
+from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
@@ -8,16 +9,21 @@ from schemas import SchemaBeaconAPI
 
 from .multi_beacon_node import MultiBeaconNode
 
+if TYPE_CHECKING:
+    from spec.base import SpecFulu
+
 
 class AttestationDataProvider:
     def __init__(
         self,
         multi_beacon_node: MultiBeaconNode,
         scheduler: AsyncIOScheduler,
+        spec: "SpecFulu",
     ):
         self.logger = logging.getLogger("AttestationData")
 
         self.multi_beacon_node = multi_beacon_node
+        self.spec = spec
 
         self._timeout_head_event_att_data = 0.5
         self._timeout_head_event_checkpoint_confirmation = 1.0
@@ -36,6 +42,23 @@ class AttestationDataProvider:
         self.target_checkpoint_confirmation_cache: dict[
             str, SchemaBeaconAPI.Checkpoint
         ] = dict()
+
+    async def handle_reorg_event(self, event: SchemaBeaconAPI.ChainReorgEvent) -> None:
+        # Check if the reorg crossed an epoch boundary.
+        # If the epoch boundary is crossed, we need to invalidate the checkpoint cache.
+        #
+        # Without the invalidation it's possible we would attest to
+        # a non-canonical (but NOT invalid) fork of the chain if a head event for
+        # that fork arrives. The head event triggers `wait_for_attestation_data` with
+        # an `expected_head_block_root` which can use cached pre-reorg FFG checkpoints
+        # that may be different from post-reorg canonical FFG checkpoints.
+        new_head_slot = int(event.slot)
+        slot_into_epoch = new_head_slot // self.spec.SLOTS_PER_EPOCH
+        epoch_boundary_crossed = int(event.depth) > slot_into_epoch
+
+        if epoch_boundary_crossed:
+            self.source_checkpoint_confirmation_cache.clear()
+            self.target_checkpoint_confirmation_cache.clear()
 
     def _cache_checkpoints(
         self, source: SchemaBeaconAPI.Checkpoint, target: SchemaBeaconAPI.Checkpoint

--- a/src/services/attestation.py
+++ b/src/services/attestation.py
@@ -35,6 +35,7 @@ class AttestationService(ValidatorDutyService):
         self.attestation_data_provider = AttestationDataProvider(
             multi_beacon_node=self.multi_beacon_node,
             scheduler=self.scheduler,
+            spec=self.spec,
         )
 
         # Attester duties by epoch

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -56,6 +56,7 @@ class ValidatorDutyService:
         self.task_manager = vero.task_manager
         self.metrics = vero.metrics
         self.cli_args = vero.cli_args
+        self.spec = vero.spec
 
         self.logger = logging.getLogger(self.__class__.__name__)
         self.tracer = trace.get_tracer(self.__class__.__name__)

--- a/tests/providers/test_attestation_data_provider.py
+++ b/tests/providers/test_attestation_data_provider.py
@@ -22,6 +22,7 @@ async def attestation_data_provider(
     adp = AttestationDataProvider(
         multi_beacon_node=multi_beacon_node,
         scheduler=vero.scheduler,
+        spec=vero.spec,
     )
     # Default timeout is 1000 ms which doesn't work well for tests
     # where the slot time is 1000 ms - it doesn't leave any room for
@@ -658,3 +659,41 @@ async def test_checkpoint_cache_pruning(
         e in attestation_data_provider.target_checkpoint_confirmation_cache
         for e in ("16", "17", "18")
     )
+
+
+@pytest.mark.parametrize(
+    argnames=("slot_into_epoch", "depth", "expected_to_invalidate"),
+    argvalues=[
+        pytest.param(
+            10, 2, False, id="does not cross epoch boundary - no invalidation"
+        ),
+        pytest.param(2, 5, True, id="crosses epoch boundary - invalidation expected"),
+    ],
+)
+async def test_reorg_checkpoint_invalidation(
+    slot_into_epoch: int,
+    depth: int,
+    expected_to_invalidate: bool,
+    attestation_data_provider: AttestationDataProvider,
+) -> None:
+    epoch = 123
+    new_head_slot = (
+        epoch * attestation_data_provider.spec.SLOTS_PER_EPOCH + slot_into_epoch
+    )
+
+    attestation_data_provider.source_checkpoint_confirmation_cache = {
+        str(epoch): SchemaBeaconAPI.Checkpoint(epoch=str(epoch), root="0x_root"),
+    }
+    await attestation_data_provider.handle_reorg_event(
+        event=SchemaBeaconAPI.ChainReorgEvent(
+            slot=str(new_head_slot),
+            depth=str(depth),
+            old_head_block="0x_old_head",
+            new_head_block="0x_new_head",
+            execution_optimistic=False,
+        )
+    )
+    if expected_to_invalidate:
+        assert len(attestation_data_provider.source_checkpoint_confirmation_cache) == 0
+    else:
+        assert len(attestation_data_provider.source_checkpoint_confirmation_cache) == 1


### PR DESCRIPTION
The `AttestationDataProvider` was registered as a reorg event handler.  The checkpoint confirmation caches will now be cleared whenever a reorg event crosses an epoch boundary.