### PR TITLE
Use 7 day dependency cooldown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.8.24
+    rev: 0.11.8
     hooks:
       - id: uv-lock
       - id: uv-export

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTHON_IMAGE_TAG="3.12-slim-bookworm@sha256:123be5684f39d8476e64f47a5fddf38f5e9d839baff5c023c815ae5bdfae0df7"
-ARG UV_IMAGE_TAG="0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c54289ced0"
+ARG PYTHON_IMAGE_TAG="3.12-slim-bookworm@sha256:58525e1a8dada8e72d6f8a11a0ddff8d981fd888549108db52455d577f927f77"
+ARG UV_IMAGE_TAG="0.11.8@sha256:de254da1c9abae7926e5cf29a6ab4a5ea65d3290682d88aa416445fa3de681bf"
 
 # uv image
 FROM ghcr.io/astral-sh/uv:${UV_IMAGE_TAG} AS uv-image
@@ -14,7 +14,7 @@ WORKDIR /vero
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential git
 
 # Install and compile dependencies
-RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
+RUN --mount=from=uv-image,source=/usr/local/bin/uv,target=/usr/local/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ ignore = ["D", "EM", "FIX", "PL", "TD", "ANN204", "ANN401", "C408", "C901", "COM
 "tests/conftest.py" = ["F401", "F403", "F811", "I"]
 
 [tool.uv]
-required-version = "~=0.8.15"
+required-version = "~=0.11.8"
+exclude-newer = "7 days"
 
 [tool.uv.sources]
 grandine-py = { git = "https://github.com/eth2353/grandine-py", rev = "v0.1.3" }

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Adds a dependency cooldown of 7 days, meaning no dependencies newer than that will be added to the lockfile when running `uv sync --upgrade`. This is a supply chain hardening feature intended to make it less likely a developer working on Vero downloads a compromised dependency, or that a shipped version of Vero contains one.

Required a bump in the uv version to support the relative time period of 7 days.