### PR TITLE
Clean up abandoned async resources properly

### DIFF
--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -139,8 +139,22 @@ class MultiBeaconNode:
             f" beacon nodes",
         )
 
+    async def _close_client_sessions(self) -> None:
+        all_beacon_nodes = self.beacon_nodes + self.beacon_nodes_proposal
+        await asyncio.gather(
+            *[
+                bn.client_session.close()
+                for bn in all_beacon_nodes
+                if not bn.client_session.closed
+            ],
+        )
+
     async def __aenter__(self) -> Self:
-        await self.initialize()
+        try:
+            await self.initialize()
+        except Exception:
+            await self._close_client_sessions()
+            raise
         return self
 
     async def __aexit__(
@@ -149,15 +163,7 @@ class MultiBeaconNode:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        all_beacon_nodes = self.beacon_nodes + self.beacon_nodes_proposal
-
-        await asyncio.gather(
-            *[
-                bn.client_session.close()
-                for bn in all_beacon_nodes
-                if not bn.client_session.closed
-            ],
-        )
+        await self._close_client_sessions()
 
     @property
     def best_beacon_node(self) -> BeaconNode:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -58,10 +58,19 @@ class TaskManager:
     ) -> None:
         """Create and track a task from the given coroutine."""
 
+        if self.shutdown_event.is_set():
+            self.logger.debug(f"Not creating task {name=}, shutting down...")
+            coro.close()
+            return
+
         async def _delayed_coro() -> None:
-            if delay > 0:
-                await asyncio.sleep(delay)
-            await coro
+            try:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                await coro
+            except asyncio.CancelledError:
+                coro.close()
+                raise
 
         task: asyncio.Task[None] = asyncio.create_task(_delayed_coro(), name=name)
         self.add_existing_task(task=task)


### PR DESCRIPTION
This is not a functional change, it just makes cleanup less noisy and gets rid of related warnings emitted during tests.