### PR TITLE
Stricten tests - treat warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ strict = true
 pythonpath = ["./src", "."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+filterwarnings = ["error"]
 
 [tool.ruff.lint]
 # Enable all rules and explicitly disable some that we don't comply with (yet?)

--- a/src/api/keymanager/_app_keys.py
+++ b/src/api/keymanager/_app_keys.py
@@ -1,0 +1,6 @@
+from aiohttp import web
+
+from providers import Keymanager
+
+APP_KEY_BEARER_TOKEN = web.AppKey("bearer_token", str)
+APP_KEY_KEYMANAGER = web.AppKey("keymanager", Keymanager)

--- a/src/api/keymanager/api.py
+++ b/src/api/keymanager/api.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 from args import CLIArgs
 
+from ._app_keys import APP_KEY_BEARER_TOKEN, APP_KEY_KEYMANAGER
 from .fee_recipient_endpoints import routes as fee_recipient_routes
 from .gas_limit_endpoints import routes as gas_limit_routes
 from .graffiti_endpoints import routes as graffiti_routes
@@ -64,8 +65,8 @@ def _create_app(keymanager: "Keymanager", cli_args: CLIArgs) -> web.Application:
         middlewares=[exception_handler, path_param_validation, bearer_authentication]
     )
 
-    app["bearer_token"] = _get_bearer_token_value(cli_args=cli_args)
-    app["keymanager"] = keymanager
+    app[APP_KEY_BEARER_TOKEN] = _get_bearer_token_value(cli_args=cli_args)
+    app[APP_KEY_KEYMANAGER] = keymanager
 
     app.add_routes(fee_recipient_routes)
     app.add_routes(gas_limit_routes)

--- a/src/api/keymanager/fee_recipient_endpoints.py
+++ b/src/api/keymanager/fee_recipient_endpoints.py
@@ -10,6 +10,8 @@ from aiohttp import web
 
 from schemas import SchemaKeymanagerAPI
 
+from ._app_keys import APP_KEY_KEYMANAGER
+
 if TYPE_CHECKING:
     from providers import Keymanager
 
@@ -19,7 +21,7 @@ routes = web.RouteTableDef()
 @routes.get("/eth/v1/validator/{pubkey}/feerecipient")
 async def fee_recipient_get(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     resp = SchemaKeymanagerAPI.ListFeeRecipientResponse(
         data=keymanager.get_fee_recipient(pubkey)
@@ -41,7 +43,7 @@ async def fee_recipient_post(request: web.Request) -> web.Response:
         )
 
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     keymanager.set_fee_recipient(pubkey=pubkey, fee_recipient=request_data.ethaddress)
 
@@ -51,7 +53,7 @@ async def fee_recipient_post(request: web.Request) -> web.Response:
 @routes.delete("/eth/v1/validator/{pubkey}/feerecipient")
 async def fee_recipient_delete(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     keymanager.delete_configured_fee_recipient(pubkey=pubkey)
 

--- a/src/api/keymanager/gas_limit_endpoints.py
+++ b/src/api/keymanager/gas_limit_endpoints.py
@@ -10,6 +10,8 @@ from aiohttp import web
 
 from schemas import SchemaKeymanagerAPI
 
+from ._app_keys import APP_KEY_KEYMANAGER
+
 if TYPE_CHECKING:
     from providers import Keymanager
 
@@ -19,7 +21,7 @@ routes = web.RouteTableDef()
 @routes.get("/eth/v1/validator/{pubkey}/gas_limit")
 async def gas_limit_get(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     resp = SchemaKeymanagerAPI.ListGasLimitResponse(
         data=keymanager.get_gas_limit(pubkey)
@@ -35,7 +37,7 @@ async def gas_limit_post(request: web.Request) -> web.Response:
     )
 
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     keymanager.set_gas_limit(pubkey=pubkey, gas_limit=request_data.gas_limit)
 
@@ -45,7 +47,7 @@ async def gas_limit_post(request: web.Request) -> web.Response:
 @routes.delete("/eth/v1/validator/{pubkey}/gas_limit")
 async def gas_limit_delete(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     keymanager.delete_configured_gas_limit(pubkey=pubkey)
 

--- a/src/api/keymanager/graffiti_endpoints.py
+++ b/src/api/keymanager/graffiti_endpoints.py
@@ -11,6 +11,8 @@ from aiohttp import web
 from schemas import SchemaKeymanagerAPI
 from spec.utils import encode_graffiti
 
+from ._app_keys import APP_KEY_KEYMANAGER
+
 if TYPE_CHECKING:
     from providers import Keymanager
 
@@ -20,7 +22,7 @@ routes = web.RouteTableDef()
 @routes.get("/eth/v1/validator/{pubkey}/graffiti")
 async def graffiti_get(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     resp = SchemaKeymanagerAPI.GraffitiResponse(data=keymanager.get_graffiti(pubkey))
 
@@ -34,7 +36,7 @@ async def graffiti_post(request: web.Request) -> web.Response:
     )
 
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     # Check if it can be encoded within 32 bytes
     _ = encode_graffiti(request_data.graffiti)
@@ -46,7 +48,7 @@ async def graffiti_post(request: web.Request) -> web.Response:
 @routes.delete("/eth/v1/validator/{pubkey}/graffiti")
 async def graffiti_delete(request: web.Request) -> web.Response:
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     keymanager.delete_configured_graffiti_value(pubkey=pubkey)
 

--- a/src/api/keymanager/middlewares.py
+++ b/src/api/keymanager/middlewares.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 import msgspec
 from aiohttp import hdrs, web
 
+from api.keymanager._app_keys import APP_KEY_BEARER_TOKEN
 from providers.keymanager import PubkeyNotFound
 from schemas.keymanager_api import PUBKEY_PATTERN, ErrorResponse
 
@@ -18,7 +19,7 @@ async def bearer_authentication(
     if not auth_header_value:
         raise web.HTTPUnauthorized(reason="No value provided for Authorization header")
 
-    if auth_header_value != f"Bearer {request.app['bearer_token']}":
+    if auth_header_value != f"Bearer {request.app[APP_KEY_BEARER_TOKEN]}":
         raise web.HTTPForbidden(
             reason="Invalid value provided for Authorization header"
         )

--- a/src/api/keymanager/remote_key_manager_endpoints.py
+++ b/src/api/keymanager/remote_key_manager_endpoints.py
@@ -10,6 +10,8 @@ from aiohttp import web
 
 from schemas import SchemaKeymanagerAPI
 
+from ._app_keys import APP_KEY_KEYMANAGER
+
 if TYPE_CHECKING:
     from providers import Keymanager
 
@@ -18,7 +20,7 @@ routes = web.RouteTableDef()
 
 @routes.get("/eth/v1/remotekeys")
 async def remote_keys_get(request: web.Request) -> web.Response:
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     remote_keys = SchemaKeymanagerAPI.ListRemoteKeysResponse(
         data=[
@@ -41,7 +43,7 @@ async def remote_keys_post(request: web.Request) -> web.Response:
         type=SchemaKeymanagerAPI.ImportRemoteKeysRequest,
     )
 
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
     import_status_messages = await keymanager.import_remote_keys(
         remote_keys=request_data.remote_keys
     )
@@ -62,7 +64,7 @@ async def remote_keys_delete(request: web.Request) -> web.Response:
         type=SchemaKeymanagerAPI.DeleteRemoteKeysRequest,
     )
 
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
     delete_status_messages = await keymanager.delete_remote_keys(
         pubkeys=request_data.pubkeys
     )

--- a/src/api/keymanager/voluntary_exit_endpoints.py
+++ b/src/api/keymanager/voluntary_exit_endpoints.py
@@ -10,6 +10,8 @@ from aiohttp import web
 
 from schemas import SchemaKeymanagerAPI
 
+from ._app_keys import APP_KEY_KEYMANAGER
+
 if TYPE_CHECKING:
     from providers import Keymanager
 
@@ -24,7 +26,7 @@ async def voluntary_exit_post(request: web.Request) -> web.Response:
         raise ValueError(f"Invalid epoch: {epoch}")
 
     pubkey = request.match_info["pubkey"]
-    keymanager: Keymanager = request.app["keymanager"]
+    keymanager: Keymanager = request.app[APP_KEY_KEYMANAGER]
 
     signed_voluntary_exit = await keymanager.sign_voluntary_exit_message(
         pubkey=pubkey,

--- a/tests/api/keymanager/conftest.py
+++ b/tests/api/keymanager/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 from aiohttp.web_app import Application
 
+from api.keymanager._app_keys import APP_KEY_BEARER_TOKEN
 from api.keymanager.api import _create_app
 from args import CLIArgs
 from providers import Keymanager
@@ -18,5 +19,5 @@ async def test_client(
 ) -> TestClient[Any, Application]:
     app = _create_app(keymanager=keymanager, cli_args=cli_args)
     return await aiohttp_client(
-        app, headers={"Authorization": f"Bearer {app['bearer_token']}"}
+        app, headers={"Authorization": f"Bearer {app[APP_KEY_BEARER_TOKEN]}"}
     )

--- a/tests/api/keymanager/test_api.py
+++ b/tests/api/keymanager/test_api.py
@@ -7,7 +7,11 @@ import pytest
 from aiohttp.test_utils import TestClient
 from aiohttp.web_app import Application
 
-from api.keymanager.api import _create_app, _get_bearer_token_value
+from api.keymanager._app_keys import APP_KEY_BEARER_TOKEN
+from api.keymanager.api import (
+    _create_app,
+    _get_bearer_token_value,
+)
 from args import CLIArgs
 from providers import Keymanager
 from schemas import SchemaKeymanagerAPI
@@ -20,7 +24,7 @@ async def test_bearer_auth(
 ) -> None:
     app = _create_app(keymanager=keymanager, cli_args=cli_args)
     test_client = await aiohttp_client(app)
-    assert len(test_client.app["bearer_token"]) == 64
+    assert len(test_client.app[APP_KEY_BEARER_TOKEN]) == 64
 
     # Make a request without a value for the Authorization header
     resp = await test_client.get(
@@ -47,7 +51,7 @@ async def test_bearer_auth(
     # Make a request with the correct value for the Authorization header
     resp = await test_client.get(
         "/eth/v1/remotekeys",
-        headers={"Authorization": f"Bearer {test_client.app['bearer_token']}"},
+        headers={"Authorization": f"Bearer {test_client.app[APP_KEY_BEARER_TOKEN]}"},
     )
     assert resp.status == 200
 

--- a/tests/providers/test_beacon_node.py
+++ b/tests/providers/test_beacon_node.py
@@ -72,3 +72,5 @@ async def test_initialize_spec_mismatch(
                 ),
             ):
                 await bn._initialize_full()
+
+        await bn.client_session.close()

--- a/tests/providers/test_doppelganger_detector.py
+++ b/tests/providers/test_doppelganger_detector.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
@@ -122,3 +123,5 @@ async def test_fetch_liveness_data(
                 validator_indices=[1, 2, 3],
             )
             assert expected_return_value == return_value
+
+    await asyncio.gather(*[bn.client_session.close() for bn in detector.beacon_nodes])

--- a/tests/services/test_event_consumer.py
+++ b/tests/services/test_event_consumer.py
@@ -92,13 +92,15 @@ async def test_handle_event(
     vero: Vero,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    bn = BeaconNode(
+        base_url="http://bn-test",
+        vero=vero,
+    )
     event_consumer._handle_event(
         event=event,
-        beacon_node=BeaconNode(
-            base_url="http://bn-test",
-            vero=vero,
-        ),
+        beacon_node=bn,
     )
+    await bn.client_session.close()
 
     for log_message in expected_log_messages:
         assert any(log_message in m for m in caplog.messages)
@@ -110,6 +112,10 @@ async def test_recent_event_keys(
     vero: Vero,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    bn = BeaconNode(
+        base_url="http://bn-test",
+        vero=vero,
+    )
     for i in range(100):
         event_consumer._handle_event(
             event=SchemaBeaconAPI.HeadEvent(
@@ -119,11 +125,9 @@ async def test_recent_event_keys(
                 previous_duty_dependent_root="0xprevious",
                 current_duty_dependent_root="0xcurrent",
             ),
-            beacon_node=BeaconNode(
-                base_url="http://bn-test",
-                vero=vero,
-            ),
+            beacon_node=bn,
         )
+    await bn.client_session.close()
 
     # The last 10 event keys should be cached
     assert len(event_consumer._recent_event_keys) == 10


### PR DESCRIPTION
Adds the `-W error` pytest flag that treats any warnings emitted during tests as errors.