### PR TITLE
Ensure attestation data wait tasks are drained on exit

### DIFF
--- a/src/providers/multi_beacon_node.py
+++ b/src/providers/multi_beacon_node.py
@@ -567,14 +567,11 @@ class MultiBeaconNode:
 
         try:
             for coro in asyncio.as_completed(tasks):
-                att_data = await coro
-                for task in tasks:
-                    task.cancel()
-                return att_data
-        except asyncio.CancelledError:
+                return await coro
+        finally:
             for task in tasks:
                 task.cancel()
-            raise
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         raise RuntimeError(
             f"Failed waiting for attestation data with block root {expected_head_block_root}"
@@ -603,13 +600,11 @@ class MultiBeaconNode:
             ):
                 await coro
                 if total_confirmations >= self._attestation_consensus_threshold:
-                    for task in tasks:
-                        task.cancel()
                     return
-        except asyncio.CancelledError:
+        finally:
             for task in tasks:
                 task.cancel()
-            raise
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def publish_attestations(
         self,


### PR DESCRIPTION
Always cancel and await per-beacon-node attestation data/checkpoint wait tasks before leaving the multi-beacon wait helpers. This makes task ownership explicit and prevents orphaned polling loops if the parent exits early.

This makes the logic more robust and may help prevent things like #249 though I have still not been able to reproduce that particular bug.