### PR TITLE
Fix race condition in duties update logic

### DIFF
--- a/docs/docs/reference/changelog.md
+++ b/docs/docs/reference/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Upcoming release
+
+#### Bugfixes
+
+- Fix race condition in duties update logic ([#339](https://github.com/serenita-org/vero/pull/339))
+
+___
+
 ## v1.4.1 { id="v1.4.1" }
 
 <small>July 14, 2026</small>&nbsp;&nbsp;&nbsp;[:octicons-mark-github-16: GitHub Release](https://github.com/serenita-org/vero/releases/tag/v1.4.1){:target="_blank"}

--- a/src/services/validator_duty_service.py
+++ b/src/services/validator_duty_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from collections.abc import AsyncIterator, Iterable
 from enum import Enum
 from types import TracebackType
@@ -149,23 +150,19 @@ class ValidatorDutyService:
         # Calls self._update_duties, retrying until it succeeds, with backoff
 
         if self._update_duties_lock.locked():
-            # Duties already being updated
-            self.logger.debug("Duties already being updated, returning...")
+            self.logger.debug("Duties are already being updated, returning...")
             return
 
         async with self._update_duties_lock:
             self.logger.info("Updating duties")
-            epoch_at_start = self.beacon_chain.current_epoch
-
             # Backoff parameters
             initial_delay = 1.0  # Starting delay between API calls
             max_delay = 10.0  # Maximum delay between API calls
             current_delay = initial_delay
 
-            while self.beacon_chain.current_epoch == epoch_at_start:
+            while True:
                 try:
                     await self._update_duties()
-                    break
                 except Exception as e:
                     self.metrics.errors_c.labels(
                         error_type=ErrorType.DUTIES_UPDATE.value
@@ -174,11 +171,22 @@ class ValidatorDutyService:
                         f"Failed to update duties: {e!r}",
                     )
 
-                    # Wait for the current delay before retrying again
+                    # Let the next epoch's scheduled update take over rather than
+                    # holding the lock throughout a backoff that crosses the
+                    # epoch boundary
+                    next_epoch = self.beacon_chain.current_epoch + 1
+                    next_epoch_start = self.beacon_chain.get_timestamp_for_slot(
+                        self.beacon_chain.compute_start_slot_at_epoch(next_epoch)
+                    )
+                    if current_delay >= (next_epoch_start - time.time()):
+                        return
+
                     await asyncio.sleep(current_delay)
 
                     # Increase the delay for the next iteration, up to the max
                     current_delay = min(current_delay * 2, max_delay)
+                else:
+                    return
 
     async def _iter_fast_then_slow_task_batches(
         self,

--- a/tests/services/test_validator_duty_service.py
+++ b/tests/services/test_validator_duty_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 
@@ -8,15 +9,53 @@ from services.validator_duty_service import (
 )
 
 
-class MockValidatorDutyService(ValidatorDutyService):
-    pass
+class DutiesUpdater:
+    def __init__(self) -> None:
+        self.update_attempts = 0
+        self.update_should_fail = False
+
+    async def __call__(self) -> None:
+        self.update_attempts += 1
+        if self.update_should_fail:
+            raise RuntimeError("Beacon node unavailable")
 
 
 @pytest.fixture
-def mock_validator_duty_service(
+def validator_duty_service(
     validator_duty_service_options: ValidatorDutyServiceOptions,
-) -> MockValidatorDutyService:
-    return MockValidatorDutyService(**validator_duty_service_options)
+) -> ValidatorDutyService:
+    return ValidatorDutyService(**validator_duty_service_options)
+
+
+async def test_failed_duties_update_hands_off_at_epoch_boundary(
+    validator_duty_service: ValidatorDutyService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    duties_updater = DutiesUpdater()
+    monkeypatch.setattr(validator_duty_service, "_update_duties", duties_updater)
+
+    beacon_chain = validator_duty_service.beacon_chain
+    next_epoch = beacon_chain.current_epoch + 1
+    next_epoch_start = beacon_chain.get_timestamp_for_slot(
+        beacon_chain.compute_start_slot_at_epoch(next_epoch)
+    )
+
+    # A failure with less than the initial backoff (1s) remaining should release the
+    # lock instead of scheduling a retry that crosses the epoch boundary
+    monkeypatch.setattr(time, "time", lambda: next_epoch_start - 0.5)
+    duties_updater.update_should_fail = True
+    async with asyncio.timeout(0.1):
+        await validator_duty_service.update_duties()
+
+    assert duties_updater.update_attempts == 1
+    assert not validator_duty_service._update_duties_lock.locked()
+
+    # The regular update at the new epoch can now acquire the lock and succeed
+    monkeypatch.setattr(time, "time", lambda: float(next_epoch_start))
+    duties_updater.update_should_fail = False
+    await validator_duty_service.update_duties()
+
+    assert duties_updater.update_attempts == 2
 
 
 @pytest.mark.parametrize(
@@ -49,7 +88,7 @@ def mock_validator_duty_service(
 async def test_iter_fast_then_slow_task_batches_yields_two_batches(
     task_delays: tuple[float, float],
     expected_batches: list[tuple[bool, list[str]]],
-    mock_validator_duty_service: MockValidatorDutyService,
+    validator_duty_service: ValidatorDutyService,
 ) -> None:
     async def _complete_after(delay: float, value: str) -> str:
         await asyncio.sleep(delay)
@@ -62,7 +101,7 @@ async def test_iter_fast_then_slow_task_batches_yields_two_batches(
     async for (
         is_slow_batch,
         batch,
-    ) in mock_validator_duty_service._iter_fast_then_slow_task_batches(
+    ) in validator_duty_service._iter_fast_then_slow_task_batches(
         tasks=[
             asyncio.create_task(_complete_after(task_1_delay, "task1")),
             asyncio.create_task(_complete_after(task_2_delay, "task2")),


### PR DESCRIPTION
A race condition could cause Vero to skip duty updates for an entire epoch (N) after failing to update duties throughout the entire previous epoch (N−1). Duty fetching would only resume in epoch N+1.

This does not affect normal operations but does delay recovery of validator duties when Vero fails to fetch duties for a prolonged period of time.

The race occurs as follows:

1) During epoch N−1, Vero repeatedly fails to fetch duties. It retries with exponential backoff, capped at 10 seconds.
2) Near the end of epoch N−1, a backoff sleep extends into epoch N while the duty-update task continues to hold the update lock.
3) At the start of epoch N, Vero schedules the normal epoch-boundary duty update. That invocation sees the lock held and returns because another update is considered in progress.
4) The task left over from epoch N−1 wakes, sees that the epoch in which it started has ended, and exits without making another attempt.
5) No duty-update task remains running during epoch N.